### PR TITLE
Determine internal status using package-info annotations

### DIFF
--- a/src/main/java/net/neoforged/jarcompatibilitychecker/core/ClassInfoComparer.java
+++ b/src/main/java/net/neoforged/jarcompatibilitychecker/core/ClassInfoComparer.java
@@ -44,7 +44,7 @@ public class ClassInfoComparer {
             List<String> internalAnnotations, InternalAnnotationCheckMode internalAnnotationCheckMode, ClassInfoCache baseCache, ClassInfo baseClassInfo,
             ClassInfoCache concreteCache, @Nullable ClassInfo concreteClassInfo) {
         ClassInfoComparisonResults results = new ClassInfoComparisonResults(baseClassInfo);
-        boolean classInternal = isInternalApi(baseClassInfo, internalAnnotations, internalAnnotationCheckMode);
+        boolean classInternal = isInternalApi(baseClassInfo, baseCache, internalAnnotations, internalAnnotationCheckMode);
 
         if (classInternal && internalAnnotationCheckMode == InternalAnnotationCheckMode.SKIP)
             return results;
@@ -117,7 +117,7 @@ public class ClassInfoComparer {
 
             boolean isStatic = (baseInfo.access & Opcodes.ACC_STATIC) != 0;
             MethodInfo inputInfo = getMethodInfo(concreteClassInfo, concreteParents, isStatic, baseInfo.name, baseInfo.desc);
-            boolean methodInternal = isInternalApi(baseInfo, internalAnnotations, internalAnnotationCheckMode);
+            boolean methodInternal = isInternalApi(baseInfo, baseCache, internalAnnotations, internalAnnotationCheckMode);
             if (methodInternal && internalAnnotationCheckMode == InternalAnnotationCheckMode.SKIP)
                 continue;
 
@@ -165,7 +165,7 @@ public class ClassInfoComparer {
         for (FieldInfo baseInfo : baseClassInfo.getFields().values()) {
             boolean isStatic = (baseInfo.access & Opcodes.ACC_STATIC) != 0;
             FieldInfo inputInfo = getFieldInfo(concreteClassInfo, concreteParents, isStatic, baseInfo.name);
-            boolean fieldInternal = isInternalApi(baseInfo, internalAnnotations, internalAnnotationCheckMode);
+            boolean fieldInternal = isInternalApi(baseInfo, baseCache, internalAnnotations, internalAnnotationCheckMode);
             if (fieldInternal && internalAnnotationCheckMode == InternalAnnotationCheckMode.SKIP)
                 continue;
 
@@ -222,12 +222,17 @@ public class ClassInfoComparer {
         return isVisible(checkBinary, baseAccess) && (baseAccess & Opcodes.ACC_FINAL) == 0 && (inputAccess & Opcodes.ACC_FINAL) != 0;
     }
 
-    public static boolean isInternalApi(MemberInfo memberInfo, List<String> internalAnnotations, InternalAnnotationCheckMode checkMode) {
+    public static boolean isInternalApi(MemberInfo memberInfo, ClassInfoCache cache, List<String> internalAnnotations, InternalAnnotationCheckMode checkMode) {
         if (checkMode == InternalAnnotationCheckMode.ERROR)
             return false; // Even if internal, we want to handle internal members like normal for ERROR check mode
 
+        String name = memberInfo.getName();
+        int idx = name.lastIndexOf('/');
+        String packageInfoName = name.substring(0, idx + 1) + "package-info";
+        ClassInfo packageInfo = cache.getMainClassInfo(packageInfoName);
+
         for (String internalAnnotation : internalAnnotations) {
-            if (memberInfo.hasAnnotation(internalAnnotation))
+            if (memberInfo.hasAnnotation(internalAnnotation) || packageInfo != null && packageInfo.hasAnnotation(internalAnnotation))
                 return true;
         }
 

--- a/src/main/java/net/neoforged/jarcompatibilitychecker/core/ClassInfoComparer.java
+++ b/src/main/java/net/neoforged/jarcompatibilitychecker/core/ClassInfoComparer.java
@@ -44,7 +44,11 @@ public class ClassInfoComparer {
             List<String> internalAnnotations, InternalAnnotationCheckMode internalAnnotationCheckMode, ClassInfoCache baseCache, ClassInfo baseClassInfo,
             ClassInfoCache concreteCache, @Nullable ClassInfo concreteClassInfo) {
         ClassInfoComparisonResults results = new ClassInfoComparisonResults(baseClassInfo);
-        boolean classInternal = isInternalApi(baseClassInfo, baseCache, internalAnnotations, internalAnnotationCheckMode);
+        String name = baseClassInfo.getName();
+        int idx = name.lastIndexOf('/');
+        String packageInfoName = name.substring(0, idx + 1) + "package-info";
+        ClassInfo packageInfo = baseCache.getMainClassInfo(packageInfoName);
+        boolean classInternal = isInternalApi(baseClassInfo, internalAnnotations, internalAnnotationCheckMode, packageInfo);
 
         if (classInternal && internalAnnotationCheckMode == InternalAnnotationCheckMode.SKIP)
             return results;
@@ -117,7 +121,7 @@ public class ClassInfoComparer {
 
             boolean isStatic = (baseInfo.access & Opcodes.ACC_STATIC) != 0;
             MethodInfo inputInfo = getMethodInfo(concreteClassInfo, concreteParents, isStatic, baseInfo.name, baseInfo.desc);
-            boolean methodInternal = isInternalApi(baseInfo, baseCache, internalAnnotations, internalAnnotationCheckMode);
+            boolean methodInternal = classInternal || isInternalApi(baseInfo, internalAnnotations, internalAnnotationCheckMode, packageInfo);
             if (methodInternal && internalAnnotationCheckMode == InternalAnnotationCheckMode.SKIP)
                 continue;
 
@@ -165,7 +169,7 @@ public class ClassInfoComparer {
         for (FieldInfo baseInfo : baseClassInfo.getFields().values()) {
             boolean isStatic = (baseInfo.access & Opcodes.ACC_STATIC) != 0;
             FieldInfo inputInfo = getFieldInfo(concreteClassInfo, concreteParents, isStatic, baseInfo.name);
-            boolean fieldInternal = isInternalApi(baseInfo, baseCache, internalAnnotations, internalAnnotationCheckMode);
+            boolean fieldInternal = classInternal || isInternalApi(baseInfo, internalAnnotations, internalAnnotationCheckMode, packageInfo);
             if (fieldInternal && internalAnnotationCheckMode == InternalAnnotationCheckMode.SKIP)
                 continue;
 
@@ -222,14 +226,9 @@ public class ClassInfoComparer {
         return isVisible(checkBinary, baseAccess) && (baseAccess & Opcodes.ACC_FINAL) == 0 && (inputAccess & Opcodes.ACC_FINAL) != 0;
     }
 
-    public static boolean isInternalApi(MemberInfo memberInfo, ClassInfoCache cache, List<String> internalAnnotations, InternalAnnotationCheckMode checkMode) {
+    public static boolean isInternalApi(MemberInfo memberInfo, List<String> internalAnnotations, InternalAnnotationCheckMode checkMode, @Nullable ClassInfo packageInfo) {
         if (checkMode == InternalAnnotationCheckMode.ERROR)
             return false; // Even if internal, we want to handle internal members like normal for ERROR check mode
-
-        String name = memberInfo.getName();
-        int idx = name.lastIndexOf('/');
-        String packageInfoName = name.substring(0, idx + 1) + "package-info";
-        ClassInfo packageInfo = cache.getMainClassInfo(packageInfoName);
 
         for (String internalAnnotation : internalAnnotations) {
             if (memberInfo.hasAnnotation(internalAnnotation) || packageInfo != null && packageInfo.hasAnnotation(internalAnnotation))

--- a/src/main/java/net/neoforged/jarcompatibilitychecker/core/ClassInfoComparer.java
+++ b/src/main/java/net/neoforged/jarcompatibilitychecker/core/ClassInfoComparer.java
@@ -226,6 +226,10 @@ public class ClassInfoComparer {
         return isVisible(checkBinary, baseAccess) && (baseAccess & Opcodes.ACC_FINAL) == 0 && (inputAccess & Opcodes.ACC_FINAL) != 0;
     }
 
+    public static boolean isInternalApi(MemberInfo memberInfo, List<String> internalAnnotations, InternalAnnotationCheckMode checkMode) {
+        return isInternalApi(memberInfo, internalAnnotations, checkMode, null);
+    }
+
     public static boolean isInternalApi(MemberInfo memberInfo, List<String> internalAnnotations, InternalAnnotationCheckMode checkMode, @Nullable ClassInfo packageInfo) {
         if (checkMode == InternalAnnotationCheckMode.ERROR)
             return false; // Even if internal, we want to handle internal members like normal for ERROR check mode


### PR DESCRIPTION
JCC currently allows excluding internal come from comparison. However, it does not account for package-level internal annotations when evaluating class members' status.

This PR adds support for reading the annotations of package-info classes when present. Packages annotated as `Internal` will have all their classes and members of their classes excluded from compatibility checks.