### PR TITLE
Fix folders on the classpath

### DIFF
--- a/src/main/java/net/neoforged/jarcompatibilitychecker/core/ClassInfoCache.java
+++ b/src/main/java/net/neoforged/jarcompatibilitychecker/core/ClassInfoCache.java
@@ -26,7 +26,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -41,7 +40,11 @@ public class ClassInfoCache {
 
         readJar(jarFile, cache.mainClasses);
         for (File libFile : libraries) {
-            readJar(libFile, cache.libClasses);
+            if (libFile.isDirectory()) {
+                readFolder(libFile.toPath(), cache.libClasses);
+            } else {
+                readJar(libFile, cache.libClasses);
+            }
         }
 
         return cache;
@@ -68,7 +71,11 @@ public class ClassInfoCache {
 
         readJar(jarPath, cache.mainClasses);
         for (Path libPath : libraries) {
-            readJar(libPath, cache.libClasses);
+            if (Files.isDirectory(libPath)) {
+                readFolder(libPath, cache.libClasses);
+            } else {
+                readJar(libPath, cache.libClasses);
+            }
         }
 
         return cache;
@@ -87,7 +94,11 @@ public class ClassInfoCache {
 
         readFolder(folder, cache.mainClasses);
         for (Path libPath : libraries) {
-            readJar(libPath, cache.libClasses);
+            if (Files.isDirectory(libPath)) {
+                readFolder(libPath, cache.libClasses);
+            } else {
+                readJar(libPath, cache.libClasses);
+            }
         }
 
         return cache;


### PR DESCRIPTION
Trying to fix this particular error that occurs when having a subproject on the classpath:

```
java.io.FileNotFoundException: Could not open JAR file: /home/runner/work/NeoForge/NeoForge/coremods/build/classes/java/main (Is a directory)
	at net.neoforged.jarcompatibilitychecker.core.ClassInfoCache.readJar(ClassInfoCache.java:134)
	at net.neoforged.jarcompatibilitychecker.core.ClassInfoCache.fromJarFile(ClassInfoCache.java:44)
	at net.neoforged.jarcompatibilitychecker.JarCompatibilityChecker.check(JarCompatibilityChecker.java:125)
	at net.neoforged.jarcompatibilitychecker.ConsoleTool.main(ConsoleTool.java:81)
	at net.neoforged.jarcompatibilitychecker.gradle.CompatibilityTask.exec(CompatibilityTask.groovy:107)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
```