### PR TITLE
Add flags to ignore certain breaking changes for Nonextendable API

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Compatibility modes:
 
 Additional API policy flags:
 - `--non-extendable-api-check-mode SKIP|WARN|ERROR` - Controls extension-only incompatibilities on base API elements marked with configured non-extendable annotations.
-  The default is `ERROR`, preserving strict compatibility unless this policy is explicitly enabled.
-  `WARN` records applicable incompatibilities as warnings instead of errors.
+  The default is `WARN`, recording applicable incompatibilities as warnings instead of errors.
+  `ERROR` preserves strict compatibility checks.
   `SKIP` suppresses applicable incompatibilities.
 - `--non-extendable-api-annotation <annotation>` - Configures the marker annotations for non-extendable API.
   This option may be repeated and defaults to `org.jetbrains.annotations.ApiStatus$NonExtendable` (`Lorg/jetbrains/annotations/ApiStatus$NonExtendable;`).
@@ -59,11 +59,11 @@ This Gradle plugin registers a `checkJarCompatibility` task that outputs the api
 (determined through the base commit of the PR in a GitHub action run, otherwise the latest version, and a list of known repositories to pull the artifact from).  
 The plugin is intended to be used alongside the [Jar Compatibility action](https://github.com/neoforged/action-jar-compatibility).
 
-The Gradle task can opt in to non-extendable API compatibility:
+The Gradle task uses non-extendable API compatibility by default, and can customize the mode or marker annotations:
 
 ```groovy
 tasks.named('checkJarCompatibility') {
-    nonExtendableApiCheckMode.set(net.neoforged.jarcompatibilitychecker.core.NonExtendableApiCheckMode.WARN)
+    nonExtendableApiCheckMode.set(net.neoforged.jarcompatibilitychecker.core.NonExtendableApiCheckMode.SKIP)
     nonExtendableApiAnnotations.set([
         'org.jetbrains.annotations.ApiStatus$NonExtendable'
     ])

--- a/README.md
+++ b/README.md
@@ -7,6 +7,23 @@ Compatibility modes:
 - **API** - Checks for compatibility between the public and protected members (API) of the base JAR and concrete JAR
 - **Binary** - Checks for binary compatibility between all members, both public and private, of the base JAR and concrete JAR
 
+Additional API policy flags:
+- `--non-extendable-api-check-mode SKIP|WARN|ERROR` - Controls extension-only incompatibilities on base API elements marked with configured non-extendable annotations.
+  The default is `ERROR`, preserving strict compatibility unless this policy is explicitly enabled.
+  `WARN` records applicable incompatibilities as warnings instead of errors.
+  `SKIP` suppresses applicable incompatibilities.
+- `--non-extendable-api-annotation <annotation>` - Configures the marker annotations for non-extendable API.
+  This option may be repeated and defaults to `org.jetbrains.annotations.ApiStatus$NonExtendable` (`Lorg/jetbrains/annotations/ApiStatus$NonExtendable;`).
+  Annotation names may be passed as Java binary class names or JVM descriptors.
+  This lets public, non-extensible APIs evolve without failing compatibility checks for changes that only affect unsupported external implementations or overrides:
+  - making a non-extendable class final;
+  - making a method abstract on a non-extendable type;
+  - making a method final on a non-extendable type, or on a method directly marked `@ApiStatus.NonExtendable`.
+  This flag does not relax binary compatibility checks.
+- `--internal-annotation-check-mode WARN|SKIP|ERROR` and `--internal-annotation <annotation>` - Controls the separate internal API policy.
+  By default, `org.jetbrains.annotations.ApiStatus$Internal` is treated as an internal API marker and internal incompatibilities are warnings.
+  This is separate from `@ApiStatus.NonExtendable`: internal API means "not public API", while non-extendable API means "public to use, unsupported to implement or subclass."
+
 It is not a goal of this tool to check for source compatibility.
 Because it operates on compiled class files located inside JARs, the tool only looks for incompatibilities that could cause exceptions and crashes at runtime.
 This means that there may be changes between the base JAR and concrete JAR which cause a source incompatibility but are not reported by this tool as it is still compatible at runtime.
@@ -41,3 +58,14 @@ A Gradle plugin with the ID `net.neoforged.jarcompatibilitychecker` is also prov
 This Gradle plugin registers a `checkJarCompatibility` task that outputs the api/binary (configurable) changes since the last release
 (determined through the base commit of the PR in a GitHub action run, otherwise the latest version, and a list of known repositories to pull the artifact from).  
 The plugin is intended to be used alongside the [Jar Compatibility action](https://github.com/neoforged/action-jar-compatibility).
+
+The Gradle task can opt in to non-extendable API compatibility:
+
+```groovy
+tasks.named('checkJarCompatibility') {
+    nonExtendableApiCheckMode.set(net.neoforged.jarcompatibilitychecker.core.NonExtendableApiCheckMode.WARN)
+    nonExtendableApiAnnotations.set([
+        'org.jetbrains.annotations.ApiStatus$NonExtendable'
+    ])
+}
+```

--- a/plugin/src/main/groovy/net/neoforged/jarcompatibilitychecker/gradle/CompatibilityTask.groovy
+++ b/plugin/src/main/groovy/net/neoforged/jarcompatibilitychecker/gradle/CompatibilityTask.groovy
@@ -4,6 +4,7 @@ import groovy.json.JsonBuilder
 import groovy.json.JsonSlurper
 import groovy.transform.CompileStatic
 import net.neoforged.jarcompatibilitychecker.ConsoleTool
+import net.neoforged.jarcompatibilitychecker.core.NonExtendableApiCheckMode
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.ProjectLayout
@@ -32,6 +33,8 @@ abstract class CompatibilityTask extends DefaultTask {
                     .flatMap { t -> version.map { ver -> t.predicate(ver) }}
         ))
         isAPI.convention(true)
+        nonExtendableApiCheckMode.convention(NonExtendableApiCheckMode.DEFAULT_MODE)
+        nonExtendableApiAnnotations.convention(NonExtendableApiCheckMode.DEFAULT_NON_EXTENDABLE_API_ANNOTATIONS)
         getMavens().convention(['https://maven.neoforged.net/releases', 'https://repo1.maven.org/maven2'])
     }
 
@@ -63,6 +66,14 @@ abstract class CompatibilityTask extends DefaultTask {
     @Input
     @Optional
     abstract Property<Boolean> getIsAPI()
+
+    @Input
+    @Optional
+    abstract Property<NonExtendableApiCheckMode> getNonExtendableApiCheckMode()
+
+    @Input
+    @Optional
+    abstract ListProperty<String> getNonExtendableApiAnnotations()
 
     @InputFiles
     abstract ConfigurableFileCollection getLibraries()
@@ -101,6 +112,15 @@ abstract class CompatibilityTask extends DefaultTask {
         if (output.isPresent()) {
             inputs.add('--output')
             inputs.add(output.asFile.get().absolutePath)
+        }
+
+        if (nonExtendableApiCheckMode.get() != NonExtendableApiCheckMode.DEFAULT_MODE) {
+            inputs.add('--non-extendable-api-check-mode')
+            inputs.add(nonExtendableApiCheckMode.get().name())
+            getNonExtendableApiAnnotations().get().forEach { String annotation ->
+                inputs.add('--non-extendable-api-annotation')
+                inputs.add(annotation)
+            }
         }
 
         libraries.forEach {

--- a/plugin/src/main/groovy/net/neoforged/jarcompatibilitychecker/gradle/CompatibilityTask.groovy
+++ b/plugin/src/main/groovy/net/neoforged/jarcompatibilitychecker/gradle/CompatibilityTask.groovy
@@ -114,10 +114,15 @@ abstract class CompatibilityTask extends DefaultTask {
             inputs.add(output.asFile.get().absolutePath)
         }
 
-        if (nonExtendableApiCheckMode.get() != NonExtendableApiCheckMode.DEFAULT_MODE) {
+        final NonExtendableApiCheckMode nonExtendableApiMode = nonExtendableApiCheckMode.get()
+        if (nonExtendableApiMode != NonExtendableApiCheckMode.DEFAULT_MODE) {
             inputs.add('--non-extendable-api-check-mode')
-            inputs.add(nonExtendableApiCheckMode.get().name())
-            getNonExtendableApiAnnotations().get().forEach { String annotation ->
+            inputs.add(nonExtendableApiMode.name())
+        }
+
+        final List<String> nonExtendableAnnotations = getNonExtendableApiAnnotations().get()
+        if (nonExtendableAnnotations != NonExtendableApiCheckMode.DEFAULT_NON_EXTENDABLE_API_ANNOTATIONS) {
+            nonExtendableAnnotations.forEach { String annotation ->
                 inputs.add('--non-extendable-api-annotation')
                 inputs.add(annotation)
             }

--- a/src/main/java/net/neoforged/jarcompatibilitychecker/ConsoleTool.java
+++ b/src/main/java/net/neoforged/jarcompatibilitychecker/ConsoleTool.java
@@ -20,6 +20,7 @@ import joptsimple.util.EnumConverter;
 import net.neoforged.jarcompatibilitychecker.core.AnnotationCheckMode;
 import net.neoforged.jarcompatibilitychecker.core.ClassInfoComparisonResults;
 import net.neoforged.jarcompatibilitychecker.core.InternalAnnotationCheckMode;
+import net.neoforged.jarcompatibilitychecker.core.NonExtendableApiCheckMode;
 import net.neoforged.jarcompatibilitychecker.json.JCCJsonEncoder;
 
 import java.io.File;
@@ -44,12 +45,20 @@ public class ConsoleTool {
             OptionSpec<File> concreteLibO = parser.acceptsAll(ImmutableList.of("concrete-lib", "concrete-library"), "Libraries that only the input JAR uses").withRequiredArg().ofType(File.class);
             OptionSpec<AnnotationCheckMode> annotationCheckModeO = parser.acceptsAll(ImmutableList.of("annotation-check-mode", "ann-mode"), "What mode to use for checking annotations")
                     .withRequiredArg().withValuesConvertedBy(new EnumConverter<AnnotationCheckMode>(AnnotationCheckMode.class) {});
-            OptionSpec<String> internalAnnotationO = parser.acceptsAll(ImmutableList.of("internal-annotation", "internal-ann"), "The fully resolved classname of an allowed internal API annotation")
+            OptionSpec<String> internalAnnotationO = parser.acceptsAll(ImmutableList.of("internal-annotation", "internal-ann"), "The binary classname or JVM descriptor of an allowed internal API annotation. Defaults to org.jetbrains.annotations.ApiStatus$Internal.")
                     .withRequiredArg().defaultsTo(InternalAnnotationCheckMode.DEFAULT_INTERNAL_ANNOTATIONS.toArray(new String[0]));
             OptionSpec<InternalAnnotationCheckMode> internalAnnotationCheckModeO = parser.acceptsAll(
                     ImmutableList.of("internal-annotation-check-mode", "internal-ann-mode"),
-                    "What mode to use for checking elements marked with an internal API annotation"
+                    "What mode to use for checking elements marked with an internal API annotation, separately from non-extendable API compatibility"
             ).withRequiredArg().withValuesConvertedBy(new EnumConverter<InternalAnnotationCheckMode>(InternalAnnotationCheckMode.class) {}).defaultsTo(InternalAnnotationCheckMode.DEFAULT_MODE);
+            OptionSpec<NonExtendableApiCheckMode> nonExtendableApiCheckModeO = parser.acceptsAll(
+                    ImmutableList.of("non-extendable-api-check-mode", "non-extendable-api-mode"),
+                    "What mode to use for checking extension-only incompatibilities on elements marked with a non-extendable API annotation"
+            ).withRequiredArg().withValuesConvertedBy(new EnumConverter<NonExtendableApiCheckMode>(NonExtendableApiCheckMode.class) {}).defaultsTo(NonExtendableApiCheckMode.DEFAULT_MODE);
+            OptionSpec<String> nonExtendableApiAnnotationO = parser.acceptsAll(
+                    ImmutableList.of("non-extendable-api-annotation", "non-extendable-api-ann"),
+                    "The binary classname or JVM descriptor of an annotation that marks non-extendable API. Defaults to org.jetbrains.annotations.ApiStatus$NonExtendable."
+            ).withRequiredArg().defaultsTo(NonExtendableApiCheckMode.DEFAULT_NON_EXTENDABLE_API_ANNOTATIONS.toArray(new String[0]));
             OptionSpec<Void> failO = parser.accepts("fail", "If enabled, the tool will fail if incompatibilities are detected");
             OptionSpec<File> outputO = parser.accepts("output", "A file to which the incompatibilities should be dumped to").withRequiredArg().ofType(File.class);
 
@@ -73,10 +82,12 @@ public class ConsoleTool {
             AnnotationCheckMode annotationCheckMode = options.valueOf(annotationCheckModeO);
             List<String> internalAnnotations = options.valuesOf(internalAnnotationO);
             InternalAnnotationCheckMode internalAnnotationCheckMode = options.valueOf(internalAnnotationCheckModeO);
+            NonExtendableApiCheckMode nonExtendableApiCheckMode = options.valueOf(nonExtendableApiCheckModeO);
+            List<String> nonExtendableApiAnnotations = options.valuesOf(nonExtendableApiAnnotationO);
 
             // TODO allow logging to a file
             JarCompatibilityChecker checker = new JarCompatibilityChecker(baseJar, inputJar, checkBinary, annotationCheckMode, internalAnnotations, internalAnnotationCheckMode,
-                    commonLibs, baseLibs, concreteLibs, System.out::println, System.err::println);
+                    nonExtendableApiCheckMode, nonExtendableApiAnnotations, commonLibs, baseLibs, concreteLibs, System.out::println, System.err::println);
 
             Map.Entry<Integer, List<ClassInfoComparisonResults>> incompatibilities = checker.check();
 

--- a/src/main/java/net/neoforged/jarcompatibilitychecker/JarCompatibilityChecker.java
+++ b/src/main/java/net/neoforged/jarcompatibilitychecker/JarCompatibilityChecker.java
@@ -11,6 +11,7 @@ import net.neoforged.jarcompatibilitychecker.core.ClassInfoComparer;
 import net.neoforged.jarcompatibilitychecker.core.ClassInfoComparisonResults;
 import net.neoforged.jarcompatibilitychecker.core.Incompatibility;
 import net.neoforged.jarcompatibilitychecker.core.InternalAnnotationCheckMode;
+import net.neoforged.jarcompatibilitychecker.core.NonExtendableApiCheckMode;
 import net.neoforged.jarcompatibilitychecker.data.ClassInfo;
 import org.jetbrains.annotations.Nullable;
 
@@ -22,7 +23,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 public class JarCompatibilityChecker {
     private final File baseJar;
@@ -32,6 +32,8 @@ public class JarCompatibilityChecker {
     private final AnnotationCheckMode annotationCheckMode;
     private final List<String> internalAnnotations;
     private final InternalAnnotationCheckMode internalAnnotationCheckMode;
+    private final NonExtendableApiCheckMode nonExtendableApiCheckMode;
+    private final List<String> nonExtendableApiAnnotations;
     private final List<File> commonLibs;
     private final List<File> baseLibs;
     private final List<File> concreteLibs;
@@ -68,20 +70,37 @@ public class JarCompatibilityChecker {
      * @param checkBinary if {@code true}, all members of the base jar including package-private and private will be checked for a match in the input jar.
      * Otherwise, only public and protected members of the base jar will be checked for a match in the input jar.
      * @param annotationCheckMode determines whether annotations will be checked and if a mismatch is an error condition
-     * @param internalAnnotations a list of fully resolved classnames for annotations that can be used to mark elements as internal API
+     * @param internalAnnotations a list of binary class names or JVM descriptors for annotations that can be used to mark elements as internal API
      * @param internalAnnotationCheckMode determines how internally-marked elements will be checked
      */
     public JarCompatibilityChecker(File baseJar, File inputJar, boolean checkBinary, @Nullable AnnotationCheckMode annotationCheckMode, List<String> internalAnnotations,
             InternalAnnotationCheckMode internalAnnotationCheckMode, List<File> commonLibs, List<File> baseLibs, List<File> concreteLibs, Consumer<String> stdLogger, Consumer<String> errLogger) {
+        this(baseJar, inputJar, checkBinary, annotationCheckMode, internalAnnotations, internalAnnotationCheckMode, NonExtendableApiCheckMode.DEFAULT_MODE,
+                NonExtendableApiCheckMode.DEFAULT_NON_EXTENDABLE_API_ANNOTATIONS, commonLibs, baseLibs, concreteLibs, stdLogger, errLogger);
+    }
+
+    /**
+     * Constructs a new JarCompatibilityChecker.
+     *
+     * @param checkBinary if {@code true}, all members of the base jar including package-private and private will be checked for a match in the input jar.
+     * Otherwise, only public and protected members of the base jar will be checked for a match in the input jar.
+     * @param annotationCheckMode determines whether annotations will be checked and if a mismatch is an error condition
+     * @param internalAnnotations a list of binary class names or JVM descriptors for annotations that can be used to mark elements as internal API
+     * @param internalAnnotationCheckMode determines how internally-marked elements will be checked
+     * @param nonExtendableApiCheckMode determines how extension-only incompatibilities on non-extendable API elements will be checked
+     * @param nonExtendableApiAnnotations a list of binary class names or JVM descriptors for annotations that mark elements as non-extendable API
+     */
+    public JarCompatibilityChecker(File baseJar, File inputJar, boolean checkBinary, @Nullable AnnotationCheckMode annotationCheckMode, List<String> internalAnnotations,
+            InternalAnnotationCheckMode internalAnnotationCheckMode, NonExtendableApiCheckMode nonExtendableApiCheckMode, List<String> nonExtendableApiAnnotations,
+            List<File> commonLibs, List<File> baseLibs, List<File> concreteLibs, Consumer<String> stdLogger, Consumer<String> errLogger) {
         this.baseJar = baseJar;
         this.inputJar = inputJar;
         this.checkBinary = checkBinary;
         this.annotationCheckMode = annotationCheckMode;
-        this.internalAnnotations = internalAnnotations == InternalAnnotationCheckMode.DEFAULT_INTERNAL_ANNOTATIONS ? internalAnnotations : internalAnnotations.stream().map(s -> {
-            boolean inDescForm = s.indexOf(';') == s.length() - 1;
-            return inDescForm ? s.replace('.', '/') : 'L' + s.replace('.', '/') + ';';
-        }).collect(Collectors.toList());
+        this.internalAnnotations = internalAnnotations;
         this.internalAnnotationCheckMode = internalAnnotationCheckMode;
+        this.nonExtendableApiCheckMode = nonExtendableApiCheckMode;
+        this.nonExtendableApiAnnotations = nonExtendableApiAnnotations;
         this.commonLibs = commonLibs;
         this.baseLibs = baseLibs;
         this.concreteLibs = concreteLibs;
@@ -108,6 +127,8 @@ public class JarCompatibilityChecker {
         log("Annotation check mode: " + (this.annotationCheckMode == null ? "NONE" : this.annotationCheckMode));
         log("Internal API annotation check mode: " + this.internalAnnotationCheckMode);
         log("Internal API annotations: " + this.internalAnnotations);
+        log("Non-extendable API annotation check mode: " + this.nonExtendableApiCheckMode);
+        log("Non-extendable API annotations: " + this.nonExtendableApiAnnotations);
         log("Base JAR: " + this.baseJar.getAbsolutePath());
         log("Input JAR: " + this.inputJar.getAbsolutePath());
         for (File baseLib : this.baseLibs) {
@@ -135,7 +156,7 @@ public class JarCompatibilityChecker {
 
             // log("Comparing " + baseClassName);
             ClassInfoComparisonResults results = ClassInfoComparer.compare(this.checkBinary, this.annotationCheckMode, this.internalAnnotations, this.internalAnnotationCheckMode,
-                    baseCache, baseClassInfo, concreteCache, concreteClassInfo);
+                    this.nonExtendableApiCheckMode, this.nonExtendableApiAnnotations, baseCache, baseClassInfo, concreteCache, concreteClassInfo);
             if (results.isIncompatible())
                 classIncompatibilities.add(results);
         }

--- a/src/main/java/net/neoforged/jarcompatibilitychecker/core/ApiStatusCompatibility.java
+++ b/src/main/java/net/neoforged/jarcompatibilitychecker/core/ApiStatusCompatibility.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.jarcompatibilitychecker.core;
+
+import com.google.common.collect.ImmutableList;
+import net.neoforged.jarcompatibilitychecker.data.MemberInfo;
+import net.neoforged.jarcompatibilitychecker.data.MethodInfo;
+
+import java.util.List;
+
+final class ApiStatusCompatibility {
+    static final String NON_EXTENDABLE = "Lorg/jetbrains/annotations/ApiStatus$NonExtendable;";
+    static final String INTERNAL = "Lorg/jetbrains/annotations/ApiStatus$Internal;";
+
+    private ApiStatusCompatibility() {}
+
+    static boolean isNonExtendableApiChange(boolean checkBinary, NonExtendableApiCheckMode nonExtendableApiCheckMode, List<String> nonExtendableApiAnnotations,
+            MemberInfo memberInfo) {
+        if (nonExtendableApiCheckMode == NonExtendableApiCheckMode.ERROR || checkBinary)
+            return false;
+        if (hasAnyAnnotation(memberInfo, nonExtendableApiAnnotations))
+            return true;
+        return memberInfo instanceof MethodInfo && hasAnyAnnotation(((MethodInfo) memberInfo).parent, nonExtendableApiAnnotations);
+    }
+
+    static boolean shouldSkip(NonExtendableApiCheckMode nonExtendableApiCheckMode, boolean nonExtendableApiChange) {
+        return nonExtendableApiChange && nonExtendableApiCheckMode == NonExtendableApiCheckMode.SKIP;
+    }
+
+    static boolean shouldError(boolean defaultIsError, boolean nonExtendableApiChange) {
+        return defaultIsError && !nonExtendableApiChange;
+    }
+
+    private static boolean hasAnyAnnotation(MemberInfo memberInfo, List<String> annotations) {
+        for (String annotation : annotations) {
+            if (memberInfo.hasAnnotation(annotation))
+                return true;
+        }
+
+        return false;
+    }
+
+    static List<String> normalizeAnnotationDescriptors(List<String> annotations) {
+        ImmutableList.Builder<String> builder = ImmutableList.builder();
+        for (String annotation : annotations) {
+            builder.add(normalizeAnnotationDescriptor(annotation));
+        }
+        return builder.build();
+    }
+
+    private static String normalizeAnnotationDescriptor(String annotation) {
+        boolean inDescForm = annotation.startsWith("L") && annotation.endsWith(";");
+        return inDescForm ? annotation.replace('.', '/') : 'L' + annotation.replace('.', '/') + ';';
+    }
+}

--- a/src/main/java/net/neoforged/jarcompatibilitychecker/core/ApiStatusCompatibility.java
+++ b/src/main/java/net/neoforged/jarcompatibilitychecker/core/ApiStatusCompatibility.java
@@ -72,7 +72,10 @@ final class ApiStatusCompatibility {
             if (baseAnnotation == null && concreteAnnotation != null) {
                 results.addAnnotationIncompatibility(memberInfo, concreteAnnotation, IncompatibilityMessages.ANNOTATION_ADDED, isError);
             } else if (baseAnnotation != null && concreteAnnotation == null) {
-                results.addAnnotationIncompatibility(memberInfo, baseAnnotation, IncompatibilityMessages.ANNOTATION_REMOVED, isError);
+                // Removing an API-status marker widens the supported contract rather
+                // than breaking existing supported callers. Keep the contract change
+                // visible, but report it as a warning by default.
+                results.addAnnotationIncompatibility(memberInfo, baseAnnotation, IncompatibilityMessages.ANNOTATION_REMOVED, false);
             }
         }
     }

--- a/src/main/java/net/neoforged/jarcompatibilitychecker/core/ApiStatusCompatibility.java
+++ b/src/main/java/net/neoforged/jarcompatibilitychecker/core/ApiStatusCompatibility.java
@@ -6,10 +6,13 @@
 package net.neoforged.jarcompatibilitychecker.core;
 
 import com.google.common.collect.ImmutableList;
+import net.neoforged.jarcompatibilitychecker.data.AnnotationInfo;
 import net.neoforged.jarcompatibilitychecker.data.MemberInfo;
 import net.neoforged.jarcompatibilitychecker.data.MethodInfo;
 
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 final class ApiStatusCompatibility {
     static final String NON_EXTENDABLE = "Lorg/jetbrains/annotations/ApiStatus$NonExtendable;";
@@ -49,6 +52,38 @@ final class ApiStatusCompatibility {
             builder.add(normalizeAnnotationDescriptor(annotation));
         }
         return builder.build();
+    }
+
+    static List<String> mergeAnnotationDescriptors(List<String> firstAnnotations, List<String> secondAnnotations) {
+        Set<String> annotations = new LinkedHashSet<>();
+        annotations.addAll(firstAnnotations);
+        annotations.addAll(secondAnnotations);
+        return ImmutableList.copyOf(annotations);
+    }
+
+    static <I extends MemberInfo> void checkApiStatusAnnotationChanges(ClassInfoComparisonResults results, I memberInfo, boolean isError,
+            List<String> apiStatusAnnotations, List<AnnotationInfo> baseAnnotations, List<AnnotationInfo> concreteAnnotations) {
+        if (apiStatusAnnotations.isEmpty() || (baseAnnotations.isEmpty() && concreteAnnotations.isEmpty()))
+            return;
+
+        for (String apiStatusAnnotation : apiStatusAnnotations) {
+            AnnotationInfo baseAnnotation = findAnnotation(baseAnnotations, apiStatusAnnotation);
+            AnnotationInfo concreteAnnotation = findAnnotation(concreteAnnotations, apiStatusAnnotation);
+            if (baseAnnotation == null && concreteAnnotation != null) {
+                results.addAnnotationIncompatibility(memberInfo, concreteAnnotation, IncompatibilityMessages.ANNOTATION_ADDED, isError);
+            } else if (baseAnnotation != null && concreteAnnotation == null) {
+                results.addAnnotationIncompatibility(memberInfo, baseAnnotation, IncompatibilityMessages.ANNOTATION_REMOVED, isError);
+            }
+        }
+    }
+
+    private static AnnotationInfo findAnnotation(List<AnnotationInfo> annotations, String desc) {
+        for (AnnotationInfo annotation : annotations) {
+            if (desc.equals(annotation.desc))
+                return annotation;
+        }
+
+        return null;
     }
 
     private static String normalizeAnnotationDescriptor(String annotation) {

--- a/src/main/java/net/neoforged/jarcompatibilitychecker/core/ClassInfoComparer.java
+++ b/src/main/java/net/neoforged/jarcompatibilitychecker/core/ClassInfoComparer.java
@@ -42,12 +42,22 @@ public class ClassInfoComparer {
     public static ClassInfoComparisonResults compare(boolean checkBinary, @Nullable AnnotationCheckMode annotationCheckMode,
             List<String> internalAnnotations, InternalAnnotationCheckMode internalAnnotationCheckMode, ClassInfoCache baseCache, ClassInfo baseClassInfo,
             ClassInfoCache concreteCache, @Nullable ClassInfo concreteClassInfo) {
+        return compare(checkBinary, annotationCheckMode, internalAnnotations, internalAnnotationCheckMode, NonExtendableApiCheckMode.DEFAULT_MODE,
+                NonExtendableApiCheckMode.DEFAULT_NON_EXTENDABLE_API_ANNOTATIONS, baseCache, baseClassInfo, concreteCache, concreteClassInfo);
+    }
+
+    public static ClassInfoComparisonResults compare(boolean checkBinary, @Nullable AnnotationCheckMode annotationCheckMode,
+            List<String> internalAnnotations, InternalAnnotationCheckMode internalAnnotationCheckMode, NonExtendableApiCheckMode nonExtendableApiCheckMode,
+            List<String> nonExtendableApiAnnotations, ClassInfoCache baseCache, ClassInfo baseClassInfo, ClassInfoCache concreteCache, @Nullable ClassInfo concreteClassInfo) {
+        internalAnnotations = ApiStatusCompatibility.normalizeAnnotationDescriptors(internalAnnotations);
+        nonExtendableApiAnnotations = ApiStatusCompatibility.normalizeAnnotationDescriptors(nonExtendableApiAnnotations);
         ClassInfoComparisonResults results = new ClassInfoComparisonResults(baseClassInfo);
         String name = baseClassInfo.getName();
         int idx = name.lastIndexOf('/');
         String packageInfoName = name.substring(0, idx + 1) + "package-info";
         ClassInfo packageInfo = baseCache.getMainClassInfo(packageInfoName);
         boolean classInternal = isInternalApi(baseClassInfo, internalAnnotations, internalAnnotationCheckMode, packageInfo);
+        NonExtendableApiCompatibility nonExtendableApiCompatibility = new NonExtendableApiCompatibility(checkBinary, nonExtendableApiCheckMode, nonExtendableApiAnnotations);
 
         if (classInternal && internalAnnotationCheckMode == InternalAnnotationCheckMode.SKIP)
             return results;
@@ -76,7 +86,10 @@ public class ClassInfoComparer {
         }
 
         if (isMadeFinal(checkBinary, baseClassInfo.access, concreteClassInfo.access)) {
-            results.addClassIncompatibility(baseClassInfo, IncompatibilityMessages.CLASS_MADE_FINAL, isClassError);
+            IncompatibilitySeverity severity = nonExtendableApiCompatibility.getSeverity(isClassError, baseClassInfo);
+            if (severity.shouldReport()) {
+                results.addClassIncompatibility(baseClassInfo, IncompatibilityMessages.CLASS_MADE_FINAL, severity.isError());
+            }
         }
 
         checkAnnotations(annotationCheckMode, results, baseClassInfo, isClassError, baseClassInfo.annotations, concreteClassInfo.annotations);
@@ -142,11 +155,17 @@ public class ClassInfoComparer {
             }
 
             if (isMadeAbstract(classVisible, baseInfo.access, inputInfo.access)) {
-                results.addMethodIncompatibility(baseInfo, IncompatibilityMessages.METHOD_MADE_ABSTRACT, isMethodError);
+                IncompatibilitySeverity severity = nonExtendableApiCompatibility.getSeverity(isMethodError, baseClassInfo);
+                if (severity.shouldReport()) {
+                    results.addMethodIncompatibility(baseInfo, IncompatibilityMessages.METHOD_MADE_ABSTRACT, severity.isError());
+                }
             }
 
             if (!classFinal && isMadeFinal(checkBinary, baseInfo.access, inputInfo.access)) {
-                results.addMethodIncompatibility(baseInfo, IncompatibilityMessages.METHOD_MADE_FINAL, isMethodError);
+                IncompatibilitySeverity severity = nonExtendableApiCompatibility.getSeverity(isMethodError, baseInfo);
+                if (severity.shouldReport()) {
+                    results.addMethodIncompatibility(baseInfo, IncompatibilityMessages.METHOD_MADE_FINAL, severity.isError());
+                }
             }
 
             checkAnnotations(annotationCheckMode, results, baseInfo, isMethodError, baseInfo.annotations, inputInfo.annotations);
@@ -157,7 +176,10 @@ public class ClassInfoComparer {
                 continue;
 
             if (classVisible && (concreteInfo.access & Opcodes.ACC_ABSTRACT) != 0) {
-                results.addMethodIncompatibility(concreteInfo, IncompatibilityMessages.METHOD_MADE_ABSTRACT);
+                IncompatibilitySeverity severity = nonExtendableApiCompatibility.getSeverity(true, baseClassInfo);
+                if (severity.shouldReport()) {
+                    results.addMethodIncompatibility(concreteInfo, IncompatibilityMessages.METHOD_MADE_ABSTRACT, severity.isError());
+                }
             }
         }
 
@@ -194,6 +216,39 @@ public class ClassInfoComparer {
         }
 
         return results;
+    }
+
+    private static final class NonExtendableApiCompatibility {
+        private final boolean checkBinary;
+        private final NonExtendableApiCheckMode checkMode;
+        private final List<String> annotations;
+
+        private NonExtendableApiCompatibility(boolean checkBinary, NonExtendableApiCheckMode checkMode, List<String> annotations) {
+            this.checkBinary = checkBinary;
+            this.checkMode = checkMode;
+            this.annotations = annotations;
+        }
+
+        private IncompatibilitySeverity getSeverity(boolean defaultIsError, MemberInfo memberInfo) {
+            boolean nonExtendableApiChange = ApiStatusCompatibility.isNonExtendableApiChange(this.checkBinary, this.checkMode, this.annotations, memberInfo);
+            if (ApiStatusCompatibility.shouldSkip(this.checkMode, nonExtendableApiChange))
+                return IncompatibilitySeverity.SKIP;
+            return ApiStatusCompatibility.shouldError(defaultIsError, nonExtendableApiChange) ? IncompatibilitySeverity.ERROR : IncompatibilitySeverity.WARNING;
+        }
+    }
+
+    private enum IncompatibilitySeverity {
+        SKIP,
+        WARNING,
+        ERROR;
+
+        private boolean shouldReport() {
+            return this != SKIP;
+        }
+
+        private boolean isError() {
+            return this == ERROR;
+        }
     }
 
     public static boolean isVisibilityLowered(boolean checkBinary, int baseAccess, int inputAccess) {

--- a/src/main/java/net/neoforged/jarcompatibilitychecker/core/ClassInfoComparer.java
+++ b/src/main/java/net/neoforged/jarcompatibilitychecker/core/ClassInfoComparer.java
@@ -58,6 +58,7 @@ public class ClassInfoComparer {
         ClassInfo packageInfo = baseCache.getMainClassInfo(packageInfoName);
         boolean classInternal = isInternalApi(baseClassInfo, internalAnnotations, internalAnnotationCheckMode, packageInfo);
         NonExtendableApiCompatibility nonExtendableApiCompatibility = new NonExtendableApiCompatibility(checkBinary, nonExtendableApiCheckMode, nonExtendableApiAnnotations);
+        List<String> apiStatusAnnotations = checkBinary ? ImmutableList.of() : ApiStatusCompatibility.mergeAnnotationDescriptors(internalAnnotations, nonExtendableApiAnnotations);
 
         if (classInternal && internalAnnotationCheckMode == InternalAnnotationCheckMode.SKIP)
             return results;
@@ -92,7 +93,8 @@ public class ClassInfoComparer {
             }
         }
 
-        checkAnnotations(annotationCheckMode, results, baseClassInfo, isClassError, baseClassInfo.annotations, concreteClassInfo.annotations);
+        ApiStatusCompatibility.checkApiStatusAnnotationChanges(results, baseClassInfo, isClassError, apiStatusAnnotations, baseClassInfo.annotations, concreteClassInfo.annotations);
+        checkAnnotations(annotationCheckMode, results, baseClassInfo, isClassError, baseClassInfo.annotations, concreteClassInfo.annotations, apiStatusAnnotations);
 
         if (baseClassInfo.superName != null) {
             ClassInfo superClassInfo = baseCache.getClassInfo(baseClassInfo.superName);
@@ -168,7 +170,8 @@ public class ClassInfoComparer {
                 }
             }
 
-            checkAnnotations(annotationCheckMode, results, baseInfo, isMethodError, baseInfo.annotations, inputInfo.annotations);
+            ApiStatusCompatibility.checkApiStatusAnnotationChanges(results, baseInfo, isMethodError, apiStatusAnnotations, baseInfo.annotations, inputInfo.annotations);
+            checkAnnotations(annotationCheckMode, results, baseInfo, isMethodError, baseInfo.annotations, inputInfo.annotations, apiStatusAnnotations);
         }
 
         for (MethodInfo concreteInfo : concreteClassInfo.getMethods().values()) {
@@ -212,7 +215,8 @@ public class ClassInfoComparer {
                 results.addFieldIncompatibility(baseInfo, IncompatibilityMessages.FIELD_MADE_FINAL, isFieldError);
             }
 
-            checkAnnotations(annotationCheckMode, results, baseInfo, isFieldError, baseInfo.annotations, inputInfo.annotations);
+            ApiStatusCompatibility.checkApiStatusAnnotationChanges(results, baseInfo, isFieldError, apiStatusAnnotations, baseInfo.annotations, inputInfo.annotations);
+            checkAnnotations(annotationCheckMode, results, baseInfo, isFieldError, baseInfo.annotations, inputInfo.annotations, apiStatusAnnotations);
         }
 
         return results;
@@ -299,6 +303,11 @@ public class ClassInfoComparer {
 
     public static <I extends MemberInfo> void checkAnnotations(@Nullable AnnotationCheckMode mode, ClassInfoComparisonResults results, I memberInfo, boolean isError,
             List<AnnotationInfo> baseAnnotations, List<AnnotationInfo> concreteAnnotations) {
+        checkAnnotations(mode, results, memberInfo, isError, baseAnnotations, concreteAnnotations, ImmutableList.of());
+    }
+
+    private static <I extends MemberInfo> void checkAnnotations(@Nullable AnnotationCheckMode mode, ClassInfoComparisonResults results, I memberInfo, boolean isError,
+            List<AnnotationInfo> baseAnnotations, List<AnnotationInfo> concreteAnnotations, List<String> ignoredAnnotations) {
         if (mode == null || (baseAnnotations.isEmpty() && concreteAnnotations.isEmpty()))
             return;
 
@@ -334,6 +343,9 @@ public class ClassInfoComparer {
             List<AnnotationInfo> baseCopy = new ArrayList<>(baseAnnotations);
 
             for (AnnotationInfo concreteAnnotation : concreteAnnotations) {
+                if (ignoredAnnotations.contains(concreteAnnotation.desc))
+                    continue;
+
                 AnnotationInfo match = null;
                 for (Iterator<AnnotationInfo> iterator = baseCopy.iterator(); iterator.hasNext(); ) {
                     AnnotationInfo baseAnnotation = iterator.next();

--- a/src/main/java/net/neoforged/jarcompatibilitychecker/core/ClassInfoComparisonResults.java
+++ b/src/main/java/net/neoforged/jarcompatibilitychecker/core/ClassInfoComparisonResults.java
@@ -60,7 +60,11 @@ public class ClassInfoComparisonResults {
     }
 
     <I extends MemberInfo> void addAnnotationIncompatibility(AnnotationCheckMode mode, I memberInfo, AnnotationInfo annotationInfo, String message, boolean isError) {
-        addIncompatibility(new AnnotationIncompatibility<>(memberInfo, annotationInfo, message, isError && mode.shouldError()));
+        addAnnotationIncompatibility(memberInfo, annotationInfo, message, isError && mode.shouldError());
+    }
+
+    <I extends MemberInfo> void addAnnotationIncompatibility(I memberInfo, AnnotationInfo annotationInfo, String message, boolean isError) {
+        addIncompatibility(new AnnotationIncompatibility<>(memberInfo, annotationInfo, message, isError));
     }
 
     /**

--- a/src/main/java/net/neoforged/jarcompatibilitychecker/core/InternalAnnotationCheckMode.java
+++ b/src/main/java/net/neoforged/jarcompatibilitychecker/core/InternalAnnotationCheckMode.java
@@ -31,5 +31,5 @@ public enum InternalAnnotationCheckMode {
     ERROR;
 
     public static final InternalAnnotationCheckMode DEFAULT_MODE = WARN;
-    public static final List<String> DEFAULT_INTERNAL_ANNOTATIONS = ImmutableList.of("Lorg/jetbrains/annotations/ApiStatus$Internal;");
+    public static final List<String> DEFAULT_INTERNAL_ANNOTATIONS = ImmutableList.of(ApiStatusCompatibility.INTERNAL);
 }

--- a/src/main/java/net/neoforged/jarcompatibilitychecker/core/NonExtendableApiCheckMode.java
+++ b/src/main/java/net/neoforged/jarcompatibilitychecker/core/NonExtendableApiCheckMode.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.jarcompatibilitychecker.core;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+/**
+ * This enum determines the check mode for extension-only incompatibilities on elements marked with non-extendable API annotations.
+ * A non-extendable API annotation can be used to mark a public API element as unsupported for external implementation, subclassing, or overriding.
+ * <p>
+ * By default, the {@linkplain #ERROR} mode is used so existing checks remain strict unless this policy is enabled.
+ */
+public enum NonExtendableApiCheckMode {
+    /**
+     * No extension-only incompatibilities will be reported for elements annotated with a non-extendable API annotation.
+     */
+    SKIP,
+    /**
+     * Extension-only incompatibilities will be lowered to warnings for elements annotated with a non-extendable API annotation.
+     */
+    WARN,
+    /**
+     * Error-level incompatibilities will be raised regardless of being marked with a non-extendable API annotation.
+     */
+    ERROR;
+
+    public static final NonExtendableApiCheckMode DEFAULT_MODE = ERROR;
+    public static final List<String> DEFAULT_NON_EXTENDABLE_API_ANNOTATIONS = ImmutableList.of(ApiStatusCompatibility.NON_EXTENDABLE);
+}

--- a/src/main/java/net/neoforged/jarcompatibilitychecker/core/NonExtendableApiCheckMode.java
+++ b/src/main/java/net/neoforged/jarcompatibilitychecker/core/NonExtendableApiCheckMode.java
@@ -13,7 +13,7 @@ import java.util.List;
  * This enum determines the check mode for extension-only incompatibilities on elements marked with non-extendable API annotations.
  * A non-extendable API annotation can be used to mark a public API element as unsupported for external implementation, subclassing, or overriding.
  * <p>
- * By default, the {@linkplain #ERROR} mode is used so existing checks remain strict unless this policy is enabled.
+ * By default, the {@linkplain #WARN} mode is used so extension-only incompatibilities are reported without failing compatibility checks.
  */
 public enum NonExtendableApiCheckMode {
     /**
@@ -29,6 +29,6 @@ public enum NonExtendableApiCheckMode {
      */
     ERROR;
 
-    public static final NonExtendableApiCheckMode DEFAULT_MODE = ERROR;
+    public static final NonExtendableApiCheckMode DEFAULT_MODE = WARN;
     public static final List<String> DEFAULT_NON_EXTENDABLE_API_ANNOTATIONS = ImmutableList.of(ApiStatusCompatibility.NON_EXTENDABLE);
 }

--- a/src/main/java/net/neoforged/jarcompatibilitychecker/json/JCCJsonEncoder.java
+++ b/src/main/java/net/neoforged/jarcompatibilitychecker/json/JCCJsonEncoder.java
@@ -3,11 +3,15 @@ package net.neoforged.jarcompatibilitychecker.json;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimaps;
 import com.google.gson.Gson;
-import com.google.gson.JsonObject;
+import net.neoforged.jarcompatibilitychecker.core.AnnotationIncompatibility;
 import net.neoforged.jarcompatibilitychecker.core.ClassIncompatibility;
 import net.neoforged.jarcompatibilitychecker.core.FieldIncompatibility;
 import net.neoforged.jarcompatibilitychecker.core.Incompatibility;
 import net.neoforged.jarcompatibilitychecker.core.MethodIncompatibility;
+import net.neoforged.jarcompatibilitychecker.data.ClassInfo;
+import net.neoforged.jarcompatibilitychecker.data.FieldInfo;
+import net.neoforged.jarcompatibilitychecker.data.MemberInfo;
+import net.neoforged.jarcompatibilitychecker.data.MethodInfo;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -25,6 +29,19 @@ public class JCCJsonEncoder {
         } else if (incompat instanceof MethodIncompatibility) {
             final MethodIncompatibility mi = (MethodIncompatibility) incompat;
             incompats.computeIfAbsent(mi.getInfo().parent.getName(), k -> new Incompat()).methodIncompatibilities.put(mi.getInfo().getName() + mi.getInfo().getDescriptor(), new Incompat.BaseIncompat(mi.getMessage(), mi.isError()));
+        } else if (incompat instanceof AnnotationIncompatibility) {
+            final AnnotationIncompatibility<?> ai = (AnnotationIncompatibility<?>) incompat;
+            final MemberInfo memberInfo = ai.getInfo();
+            final Incompat.BaseIncompat encoded = new Incompat.BaseIncompat(ai.getAnnotationInfo() + " - " + ai.getMessage(), ai.isError());
+            if (memberInfo instanceof ClassInfo) {
+                incompats.computeIfAbsent(memberInfo.getName(), k -> new Incompat()).classIncompatibilities.add(encoded);
+            } else if (memberInfo instanceof FieldInfo) {
+                final FieldInfo fi = (FieldInfo) memberInfo;
+                incompats.computeIfAbsent(fi.parent.getName(), k -> new Incompat()).fieldIncompatibilities.put(fi.getName() + ":" + fi.getDescriptor(), encoded);
+            } else if (memberInfo instanceof MethodInfo) {
+                final MethodInfo mi = (MethodInfo) memberInfo;
+                incompats.computeIfAbsent(mi.parent.getName(), k -> new Incompat()).methodIncompatibilities.put(mi.getName() + mi.getDescriptor(), encoded);
+            }
         }
     }
 

--- a/src/test/java/net/neoforged/jarcompatibilitychecker/test/ApiStatusCompatibilityTests.java
+++ b/src/test/java/net/neoforged/jarcompatibilitychecker/test/ApiStatusCompatibilityTests.java
@@ -36,7 +36,7 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
     // Cases that ApiStatus compatibility can downgrade or suppress
 
     @Test
-    public void testNonExtendableApiClassMadeFinalWarnsByDefault() {
+    public void nonExtendableApiClassMadeFinalWarnsByDefault() {
         // Making a public class final breaks external subclasses, but @NonExtendable
         // marks subclassing as not supported, so the break is downgraded to a warning.
         fixtureComparison("Class/PublicClassMadeFinal", "A")
@@ -46,7 +46,7 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
     }
 
     @Test
-    public void testNonExtendableApiMethodMadeAbstractWarnsByDefault() {
+    public void nonExtendableApiMethodMadeAbstractWarnsByDefault() {
         // Making a method abstract breaks subclasses that rely on the implementation,
         // but @NonExtendable marks subclassing as not supported, so the break is
         // downgraded to a warning.
@@ -57,7 +57,7 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
     }
 
     @Test
-    public void testNonExtendableApiMethodMadeFinalWarnsByDefault() {
+    public void nonExtendableApiMethodMadeFinalWarnsByDefault() {
         // Making a method final breaks overrides, but @NonExtendable marks subclassing
         // as not supported, so the break is downgraded to a warning.
         fixtureComparison("Method/PublicMethodMadeFinal", "A")
@@ -67,7 +67,7 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
     }
 
     @Test
-    public void testNonExtendableMethodAnnotationAllowsMethodMadeFinal() {
+    public void nonExtendableMethodAnnotationAllowsMethodMadeFinal() {
         // Making a method final breaks overrides, but method-level @NonExtendable
         // marks overriding as not supported, so the break is downgraded to a warning.
         fixtureComparison("Method/PublicMethodMadeFinal", "A")
@@ -77,7 +77,7 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
     }
 
     @Test
-    public void testNonExtendableApiCheckModeSkipSuppressesAllowedIncompatibility() {
+    public void nonExtendableApiCheckModeSkipSuppressesAllowedIncompatibility() {
         // SKIP mode suppresses extension-only breaks when the API marks extension as
         // not supported, so the result remains compatible.
         fixtureComparison("Class/PublicClassMadeFinal", "A")
@@ -88,7 +88,7 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
     }
 
     @Test
-    public void testCustomNonExtendableAnnotationWarnsWhenConfigured() {
+    public void customNonExtendableAnnotationWarnsWhenConfigured() {
         // Configured custom markers use the same contract as @NonExtendable, so
         // extension-only breaks are downgraded to warnings.
         fixtureComparison("Class/PublicClassMadeFinal", "A")
@@ -99,7 +99,7 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
     }
 
     @Test
-    public void testNonExtendableAnnotationBinaryNameIsNormalized() {
+    public void nonExtendableAnnotationBinaryNameIsNormalized() {
         // Binary-name configuration resolves to the same marker descriptor, so the
         // same @NonExtendable compatibility policy applies.
         fixtureComparison("Class/PublicClassMadeFinal", "A")
@@ -110,7 +110,7 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
     }
 
     @Test
-    public void testInternalApiStatusCanWarnUsingSeparateCheckMode() {
+    public void internalApiStatusCanWarnUsingSeparateCheckMode() {
         // Deleting a visible class breaks callers, but @Internal marks the class as
         // not part of the supported API, so WARN mode downgrades the break to a warning.
         fixtureComparison("Class/InternalClassDeleted", "A")
@@ -122,7 +122,7 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
     // ApiStatus marker annotations are compatibility-affecting API contract changes
 
     @Test
-    public void testInternalAnnotationAddedToClassIsReportedAsError() {
+    public void internalAnnotationAddedToClassIsReportedAsError() {
         // Adding @Internal removes the class from the supported API contract, so the
         // annotation change is reported as an error.
         assertClassIncompatible(
@@ -133,7 +133,7 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
     }
 
     @Test
-    public void testInternalAnnotationRemovedFromClassWarnsByDefault() {
+    public void internalAnnotationRemovedFromClassWarnsByDefault() {
         // Removing @Internal adds the class to the supported API contract. That
         // widens the contract, so the annotation change is reported as a warning.
         assertClassIncompatible(
@@ -145,7 +145,7 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
     }
 
     @Test
-    public void testInternalAnnotationAddedToMethodIsReportedAsError() {
+    public void internalAnnotationAddedToMethodIsReportedAsError() {
         // Adding @Internal removes the method from the supported API contract, so the
         // annotation change is reported as an error.
         assertIncompatible(
@@ -159,7 +159,7 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
     }
 
     @Test
-    public void testInternalAnnotationRemovedFromMethodWarnsByDefault() {
+    public void internalAnnotationRemovedFromMethodWarnsByDefault() {
         // Removing @Internal adds the method to the supported API contract. That
         // widens the contract, so the annotation change is reported as a warning.
         assertIncompatible(
@@ -173,7 +173,7 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
     }
 
     @Test
-    public void testNonExtendableAnnotationAddedToClassIsReportedAsError() {
+    public void nonExtendableAnnotationAddedToClassIsReportedAsError() {
         // Adding @NonExtendable removes supported subclassing from the class contract,
         // so the annotation change is reported as an error.
         assertClassIncompatible(
@@ -184,7 +184,7 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
     }
 
     @Test
-    public void testNonExtendableAnnotationRemovedFromClassWarnsByDefault() {
+    public void nonExtendableAnnotationRemovedFromClassWarnsByDefault() {
         // Removing @NonExtendable adds supported subclassing to the class contract.
         // That widens the contract, so the annotation change is reported as a warning.
         assertClassIncompatible(
@@ -196,7 +196,7 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
     }
 
     @Test
-    public void testNonExtendableAnnotationAddedToMethodIsReportedAsError() {
+    public void nonExtendableAnnotationAddedToMethodIsReportedAsError() {
         // Adding @NonExtendable removes supported overriding from the method contract,
         // so the annotation change is reported as an error.
         assertIncompatible(
@@ -210,7 +210,7 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
     }
 
     @Test
-    public void testNonExtendableAnnotationRemovedFromMethodWarnsByDefault() {
+    public void nonExtendableAnnotationRemovedFromMethodWarnsByDefault() {
         // Removing @NonExtendable adds supported overriding to the method contract.
         // That widens the contract, so the annotation change is reported as a warning.
         assertIncompatible(
@@ -226,7 +226,7 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
     // Cases that can be kept strict with ERROR mode
 
     @Test
-    public void testNonExtendableApiClassMadeFinalInErrorModeRemainsError() {
+    public void nonExtendableApiClassMadeFinalInErrorModeRemainsError() {
         // ERROR mode keeps extension-only breaks as errors, so finalizing the class
         // reports a subclassing compatibility break.
         fixtureComparison("Class/PublicClassMadeFinal", "A")
@@ -237,7 +237,7 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
     }
 
     @Test
-    public void testNonExtendableApiMethodMadeAbstractInErrorModeRemainsError() {
+    public void nonExtendableApiMethodMadeAbstractInErrorModeRemainsError() {
         // ERROR mode keeps extension-only breaks as errors, so making the method
         // abstract reports a subclassing compatibility break.
         fixtureComparison("Method/PublicMethodMadeAbstract", "A")
@@ -248,7 +248,7 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
     }
 
     @Test
-    public void testNonExtendableApiMethodMadeFinalInErrorModeRemainsError() {
+    public void nonExtendableApiMethodMadeFinalInErrorModeRemainsError() {
         // ERROR mode keeps extension-only breaks as errors, so making the method final
         // reports an overriding compatibility break.
         fixtureComparison("Method/PublicMethodMadeFinal", "A")
@@ -261,7 +261,7 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
     // Cases that should still report errors even with the most permissive non-extendable mode
 
     @Test
-    public void testCustomNonExtendableAnnotationRequiresConfiguration() {
+    public void customNonExtendableAnnotationRequiresConfiguration() {
         // Unconfigured custom markers have no compatibility policy, so finalizing the
         // class reports a subclassing compatibility break.
         fixtureComparison("Class/PublicClassMadeFinal", "A")
@@ -272,7 +272,7 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
     }
 
     @Test
-    public void testNonExtendableBinaryClassMadeFinalRemainsError() {
+    public void nonExtendableBinaryClassMadeFinalRemainsError() {
         // Binary mode checks JVM compatibility, so API policy markers cannot downgrade
         // final-class breaks to warnings.
         fixtureComparison("Class/PublicClassMadeFinal", "A")
@@ -283,7 +283,7 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
     }
 
     @Test
-    public void testNonExtendableBinaryMethodMadeAbstractRemainsError() {
+    public void nonExtendableBinaryMethodMadeAbstractRemainsError() {
         // Binary mode checks JVM compatibility, so API policy markers cannot downgrade
         // abstract-method breaks to warnings.
         fixtureComparison("Method/PublicMethodMadeAbstract", "A")
@@ -294,7 +294,7 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
     }
 
     @Test
-    public void testNonExtendableDoesNotAllowUnrelatedIncompatibilities() {
+    public void nonExtendableDoesNotAllowUnrelatedIncompatibilities() {
         // Making a public field final is not an extension-only break, so
         // @NonExtendable cannot downgrade or suppress it.
         fixtureComparison("Field/PublicFieldMadeFinal", "A")
@@ -305,14 +305,14 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
     }
 
     @Test
-    public void testOuterNonExtendableAnnotationDoesNotApplyToNestedClass() {
+    public void outerNonExtendableAnnotationDoesNotApplyToNestedClass() {
         // A nested class is a separate API element, so an outer @NonExtendable marker
         // cannot downgrade or suppress the nested class's subclassing break.
         assertClassIncompatible(compareNestedClassMadeFinalWithNonExtendableOuter(), "Outer$Nested", IncompatibilityMessages.CLASS_MADE_FINAL);
     }
 
     @Test
-    public void testInternalApiStatusCanRemainErrorUsingSeparateCheckMode() {
+    public void internalApiStatusCanRemainErrorUsingSeparateCheckMode() {
         // ERROR mode keeps @Internal elements in strict API checks, so deleting the
         // class reports a compatibility error.
         fixtureComparison("Class/InternalClassDeleted", "A")

--- a/src/test/java/net/neoforged/jarcompatibilitychecker/test/ApiStatusCompatibilityTests.java
+++ b/src/test/java/net/neoforged/jarcompatibilitychecker/test/ApiStatusCompatibilityTests.java
@@ -1,0 +1,356 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.jarcompatibilitychecker.test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import net.neoforged.jarcompatibilitychecker.core.ClassInfoCache;
+import net.neoforged.jarcompatibilitychecker.core.ClassInfoComparer;
+import net.neoforged.jarcompatibilitychecker.core.ClassInfoComparisonResults;
+import net.neoforged.jarcompatibilitychecker.core.IncompatibilityMessages;
+import net.neoforged.jarcompatibilitychecker.core.InternalAnnotationCheckMode;
+import net.neoforged.jarcompatibilitychecker.core.NonExtendableApiCheckMode;
+import net.neoforged.jarcompatibilitychecker.data.AnnotationInfo;
+import net.neoforged.jarcompatibilitychecker.data.ClassInfo;
+import net.neoforged.jarcompatibilitychecker.data.MemberInfo;
+import net.neoforged.jarcompatibilitychecker.data.MethodInfo;
+import org.junit.Assert;
+import org.junit.Test;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.ClassNode;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
+    private static final String NON_EXTENDABLE = NonExtendableApiCheckMode.DEFAULT_NON_EXTENDABLE_API_ANNOTATIONS.get(0);
+    private static final String CUSTOM_NON_EXTENDABLE = "Lcom/example/NonExtendable;";
+
+    // Cases that ApiStatus compatibility can downgrade or suppress
+
+    @Test
+    public void testNonExtendableApiClassMadeFinalWarnsWhenOptedIn() {
+        // Making a non-extendable public class final can be downgraded to a warning
+        fixtureComparison("Class/PublicClassMadeFinal", "A")
+                .api()
+                .withNonExtendableApiMode(NonExtendableApiCheckMode.WARN)
+                .withBaseClassAnnotation(NON_EXTENDABLE)
+                .assertClassWarning(IncompatibilityMessages.CLASS_MADE_FINAL);
+    }
+
+    @Test
+    public void testNonExtendableApiMethodMadeAbstractWarnsWhenOptedIn() {
+        // Making a method abstract on a non-extendable type can be downgraded to a warning
+        fixtureComparison("Method/PublicMethodMadeAbstract", "A")
+                .api()
+                .withNonExtendableApiMode(NonExtendableApiCheckMode.WARN)
+                .withBaseClassAnnotation(NON_EXTENDABLE)
+                .assertMemberWarning("thing", "()V", IncompatibilityMessages.METHOD_MADE_ABSTRACT);
+    }
+
+    @Test
+    public void testNonExtendableApiMethodMadeFinalWarnsWhenOptedIn() {
+        // Making a method final on a non-extendable type can be downgraded to a warning
+        fixtureComparison("Method/PublicMethodMadeFinal", "A")
+                .api()
+                .withNonExtendableApiMode(NonExtendableApiCheckMode.WARN)
+                .withBaseClassAnnotation(NON_EXTENDABLE)
+                .assertMemberWarning("thing", "()V", IncompatibilityMessages.METHOD_MADE_FINAL);
+    }
+
+    @Test
+    public void testNonExtendableMethodAnnotationAllowsMethodMadeFinal() {
+        // A method can be marked non-extendable directly
+        fixtureComparison("Method/PublicMethodMadeFinal", "A")
+                .api()
+                .withNonExtendableApiMode(NonExtendableApiCheckMode.WARN)
+                .withBaseMethodAnnotation("thing", "()V", NON_EXTENDABLE)
+                .assertMemberWarning("thing", "()V", IncompatibilityMessages.METHOD_MADE_FINAL);
+    }
+
+    @Test
+    public void testNonExtendableApiCheckModeSkipSuppressesAllowedIncompatibility() {
+        // SKIP suppresses otherwise-allowed non-extendable API incompatibilities, matching internal API mode behavior
+        fixtureComparison("Class/PublicClassMadeFinal", "A")
+                .api()
+                .withNonExtendableApiMode(NonExtendableApiCheckMode.SKIP)
+                .withBaseClassAnnotation(NON_EXTENDABLE)
+                .assertCompatible();
+    }
+
+    @Test
+    public void testCustomNonExtendableAnnotationWarnsWhenConfigured() {
+        // Custom non-extendable annotations apply when configured
+        fixtureComparison("Class/PublicClassMadeFinal", "A")
+                .api()
+                .withNonExtendableApiMode(NonExtendableApiCheckMode.WARN)
+                .withNonExtendableApiAnnotations(ImmutableList.of(CUSTOM_NON_EXTENDABLE))
+                .withBaseClassAnnotation(CUSTOM_NON_EXTENDABLE)
+                .assertClassWarning(IncompatibilityMessages.CLASS_MADE_FINAL);
+    }
+
+    @Test
+    public void testNonExtendableAnnotationBinaryNameIsNormalized() {
+        // Configured annotations may use Java binary names instead of JVM descriptors
+        fixtureComparison("Class/PublicClassMadeFinal", "A")
+                .api()
+                .withNonExtendableApiMode(NonExtendableApiCheckMode.WARN)
+                .withNonExtendableApiAnnotations(ImmutableList.of("org.jetbrains.annotations.ApiStatus$NonExtendable"))
+                .withBaseClassAnnotation(NON_EXTENDABLE)
+                .assertClassWarning(IncompatibilityMessages.CLASS_MADE_FINAL);
+    }
+
+    @Test
+    public void testInternalApiStatusCanWarnUsingSeparateCheckMode() {
+        // Internal API remains controlled by the internal annotation mode, separately from non-extendable API compatibility
+        fixtureComparison("Class/InternalClassDeleted", "A")
+                .api()
+                .withInternalAnnotationMode(InternalAnnotationCheckMode.WARN)
+                .assertClassWarning(IncompatibilityMessages.API_CLASS_MISSING);
+    }
+
+    // Cases that require opting in to ApiStatus compatibility
+
+    @Test
+    public void testNonExtendableApiClassMadeFinalWithoutOptInRemainsError() {
+        // Making a non-extendable public class final is still an error unless the non-extendable policy is enabled
+        fixtureComparison("Class/PublicClassMadeFinal", "A")
+                .api()
+                .withBaseClassAnnotation(NON_EXTENDABLE)
+                .assertClassError(IncompatibilityMessages.CLASS_MADE_FINAL);
+    }
+
+    @Test
+    public void testNonExtendableApiMethodMadeAbstractWithoutOptInRemainsError() {
+        // Making a method abstract on a non-extendable type is still an error unless the non-extendable policy is enabled
+        fixtureComparison("Method/PublicMethodMadeAbstract", "A")
+                .api()
+                .withBaseClassAnnotation(NON_EXTENDABLE)
+                .assertMemberError("thing", "()V", IncompatibilityMessages.METHOD_MADE_ABSTRACT);
+    }
+
+    @Test
+    public void testNonExtendableApiMethodMadeFinalWithoutOptInRemainsError() {
+        // Making a method final on a non-extendable type is still an error unless the non-extendable policy is enabled
+        fixtureComparison("Method/PublicMethodMadeFinal", "A")
+                .api()
+                .withBaseClassAnnotation(NON_EXTENDABLE)
+                .assertMemberError("thing", "()V", IncompatibilityMessages.METHOD_MADE_FINAL);
+    }
+
+    // Cases that should still report errors even with the most permissive non-extendable mode
+
+    @Test
+    public void testCustomNonExtendableAnnotationRequiresConfiguration() {
+        // Custom non-extendable annotations only apply when configured
+        fixtureComparison("Class/PublicClassMadeFinal", "A")
+                .api()
+                .withNonExtendableApiMode(NonExtendableApiCheckMode.SKIP)
+                .withBaseClassAnnotation(CUSTOM_NON_EXTENDABLE)
+                .assertClassError(IncompatibilityMessages.CLASS_MADE_FINAL);
+    }
+
+    @Test
+    public void testNonExtendableBinaryClassMadeFinalRemainsError() {
+        // Non-extendable API compatibility does not relax binary compatibility
+        fixtureComparison("Class/PublicClassMadeFinal", "A")
+                .binary()
+                .withNonExtendableApiMode(NonExtendableApiCheckMode.SKIP)
+                .withBaseClassAnnotation(NON_EXTENDABLE)
+                .assertClassError(IncompatibilityMessages.CLASS_MADE_FINAL);
+    }
+
+    @Test
+    public void testNonExtendableBinaryMethodMadeAbstractRemainsError() {
+        // Non-extendable API compatibility does not relax binary compatibility
+        fixtureComparison("Method/PublicMethodMadeAbstract", "A")
+                .binary()
+                .withNonExtendableApiMode(NonExtendableApiCheckMode.SKIP)
+                .withBaseClassAnnotation(NON_EXTENDABLE)
+                .assertMemberError("thing", "()V", IncompatibilityMessages.METHOD_MADE_ABSTRACT);
+    }
+
+    @Test
+    public void testNonExtendableDoesNotAllowUnrelatedIncompatibilities() {
+        // Non-extendable API compatibility only applies to extension-only incompatibilities
+        fixtureComparison("Field/PublicFieldMadeFinal", "A")
+                .api()
+                .withNonExtendableApiMode(NonExtendableApiCheckMode.SKIP)
+                .withBaseClassAnnotation(NON_EXTENDABLE)
+                .assertMemberError("buzz", "Z", IncompatibilityMessages.FIELD_MADE_FINAL);
+    }
+
+    @Test
+    public void testOuterNonExtendableAnnotationDoesNotApplyToNestedClass() {
+        // Marking an outer class non-extendable does not mark its nested class non-extendable
+        assertClassIncompatible(compareNestedClassMadeFinalWithNonExtendableOuter(), "Outer$Nested", IncompatibilityMessages.CLASS_MADE_FINAL);
+    }
+
+    @Test
+    public void testInternalApiStatusCanRemainErrorUsingSeparateCheckMode() {
+        // Internal API remains controlled by the internal annotation mode, separately from non-extendable API compatibility
+        fixtureComparison("Class/InternalClassDeleted", "A")
+                .api()
+                .withNonExtendableApiMode(NonExtendableApiCheckMode.SKIP)
+                .withInternalAnnotationMode(InternalAnnotationCheckMode.ERROR)
+                .assertClassError(IncompatibilityMessages.API_CLASS_MISSING);
+    }
+
+    private FixtureComparisonBuilder fixtureComparison(String folderName, String className) {
+        return new FixtureComparisonBuilder(folderName, className);
+    }
+
+    private ClassInfoComparisonResults compareNestedClassMadeFinalWithNonExtendableOuter() {
+        ClassInfo outerClass = publicClass("Outer", NON_EXTENDABLE);
+        ClassInfo baseNestedClass = publicClass("Outer$Nested");
+        ClassInfo inputNestedClass = publicFinalClass("Outer$Nested");
+
+        ClassInfoCache baseCache = ClassInfoCache.fromMaps(ImmutableMap.of(
+                outerClass.getName(), outerClass,
+                baseNestedClass.getName(), baseNestedClass
+        ), ImmutableMap.of());
+        ClassInfoCache inputCache = ClassInfoCache.fromMaps(ImmutableMap.of(inputNestedClass.getName(), inputNestedClass), ImmutableMap.of());
+
+        return ClassInfoComparer.compare(
+                false,
+                null,
+                InternalAnnotationCheckMode.DEFAULT_INTERNAL_ANNOTATIONS,
+                InternalAnnotationCheckMode.ERROR,
+                NonExtendableApiCheckMode.SKIP,
+                NonExtendableApiCheckMode.DEFAULT_NON_EXTENDABLE_API_ANNOTATIONS,
+                baseCache,
+                baseNestedClass,
+                inputCache,
+                inputNestedClass
+        );
+    }
+
+    private final class FixtureComparisonBuilder {
+        private final String folderName;
+        private final String className;
+        private Boolean checkBinary;
+        private InternalAnnotationCheckMode internalAnnotationCheckMode = InternalAnnotationCheckMode.ERROR;
+        private NonExtendableApiCheckMode nonExtendableApiCheckMode = NonExtendableApiCheckMode.DEFAULT_MODE;
+        private List<String> nonExtendableApiAnnotations = NonExtendableApiCheckMode.DEFAULT_NON_EXTENDABLE_API_ANNOTATIONS;
+        private Consumer<ClassInfo> baseClassConfigurer = classInfo -> {};
+
+        private FixtureComparisonBuilder(String folderName, String className) {
+            this.folderName = folderName;
+            this.className = className;
+        }
+
+        private FixtureComparisonBuilder api() {
+            this.checkBinary = false;
+            return this;
+        }
+
+        private FixtureComparisonBuilder binary() {
+            this.checkBinary = true;
+            return this;
+        }
+
+        private FixtureComparisonBuilder withInternalAnnotationMode(InternalAnnotationCheckMode internalAnnotationCheckMode) {
+            this.internalAnnotationCheckMode = internalAnnotationCheckMode;
+            return this;
+        }
+
+        private FixtureComparisonBuilder withNonExtendableApiMode(NonExtendableApiCheckMode nonExtendableApiCheckMode) {
+            this.nonExtendableApiCheckMode = nonExtendableApiCheckMode;
+            return this;
+        }
+
+        private FixtureComparisonBuilder withNonExtendableApiAnnotations(List<String> nonExtendableApiAnnotations) {
+            this.nonExtendableApiAnnotations = nonExtendableApiAnnotations;
+            return this;
+        }
+
+        private FixtureComparisonBuilder withBaseClassAnnotation(String annotation) {
+            return withBaseClass(classInfo -> annotate(classInfo, annotation));
+        }
+
+        private FixtureComparisonBuilder withBaseMethodAnnotation(String name, String desc, String annotation) {
+            return withBaseClass(classInfo -> {
+                MethodInfo methodInfo = classInfo.getMethod(name, desc);
+                Assert.assertNotNull("Method " + name + desc + " not found", methodInfo);
+                annotate(methodInfo, annotation);
+            });
+        }
+
+        private FixtureComparisonBuilder withBaseClass(Consumer<ClassInfo> configurer) {
+            Consumer<ClassInfo> previousConfigurer = this.baseClassConfigurer;
+            this.baseClassConfigurer = classInfo -> {
+                previousConfigurer.accept(classInfo);
+                configurer.accept(classInfo);
+            };
+            return this;
+        }
+
+        private void assertClassError(String message) {
+            assertClassIncompatible(results(), this.className, message);
+        }
+
+        private void assertClassWarning(String message) {
+            assertClassIncompatible(results(), this.className, false, message);
+        }
+
+        private void assertMemberError(String name, String desc, String message) {
+            assertIncompatible(results(), this.className, name, desc, true, message);
+        }
+
+        private void assertMemberWarning(String name, String desc, String message) {
+            assertIncompatible(results(), this.className, name, desc, false, message);
+        }
+
+        private void assertCompatible() {
+            ApiStatusCompatibilityTests.this.assertCompatible(results(), this.className);
+        }
+
+        private ClassInfoComparisonResults results() {
+            Assert.assertNotNull("Compatibility mode must be configured with api() or binary()", this.checkBinary);
+            return getComparisonResults(this.folderName, this.className, (baseCache, baseClassInfo, inputCache, inputClassInfo) -> {
+                this.baseClassConfigurer.accept(baseClassInfo);
+                return ClassInfoComparer.compare(
+                        this.checkBinary,
+                        null,
+                        InternalAnnotationCheckMode.DEFAULT_INTERNAL_ANNOTATIONS,
+                        this.internalAnnotationCheckMode,
+                        this.nonExtendableApiCheckMode,
+                        this.nonExtendableApiAnnotations,
+                        baseCache,
+                        baseClassInfo,
+                        inputCache,
+                        inputClassInfo
+                );
+            });
+        }
+    }
+
+    private static void annotate(MemberInfo memberInfo, String annotation) {
+        memberInfo.getAnnotations().add(new AnnotationInfo(annotation, ImmutableList.of()));
+    }
+
+    private static ClassInfo publicClass(String name, String... annotations) {
+        return classInfo(name, Opcodes.ACC_PUBLIC | Opcodes.ACC_SUPER, annotations);
+    }
+
+    private static ClassInfo publicFinalClass(String name, String... annotations) {
+        return classInfo(name, Opcodes.ACC_PUBLIC | Opcodes.ACC_SUPER | Opcodes.ACC_FINAL, annotations);
+    }
+
+    private static ClassInfo classInfo(String name, int access, String... annotations) {
+        ClassNode node = new ClassNode();
+        node.version = Opcodes.V1_8;
+        node.access = access;
+        node.name = name;
+        node.superName = "java/lang/Object";
+
+        ClassInfo classInfo = new ClassInfo(node);
+        for (String annotation : annotations) {
+            annotate(classInfo, annotation);
+        }
+        return classInfo;
+    }
+}

--- a/src/test/java/net/neoforged/jarcompatibilitychecker/test/ApiStatusCompatibilityTests.java
+++ b/src/test/java/net/neoforged/jarcompatibilitychecker/test/ApiStatusCompatibilityTests.java
@@ -21,174 +21,298 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.MethodNode;
 
 import java.util.List;
 import java.util.function.Consumer;
 
 public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
+    private static final String INTERNAL = InternalAnnotationCheckMode.DEFAULT_INTERNAL_ANNOTATIONS.get(0);
     private static final String NON_EXTENDABLE = NonExtendableApiCheckMode.DEFAULT_NON_EXTENDABLE_API_ANNOTATIONS.get(0);
     private static final String CUSTOM_NON_EXTENDABLE = "Lcom/example/NonExtendable;";
+    private static final String METHOD_NAME = "thing";
+    private static final String METHOD_DESC = "()V";
 
     // Cases that ApiStatus compatibility can downgrade or suppress
 
     @Test
     public void testNonExtendableApiClassMadeFinalWarnsByDefault() {
-        // Making a non-extendable public class final is reported as a warning by default
+        // Making a public class final breaks external subclasses, but @NonExtendable
+        // marks subclassing as not supported, so the break is downgraded to a warning.
         fixtureComparison("Class/PublicClassMadeFinal", "A")
                 .api()
-                .withBaseClassAnnotation(NON_EXTENDABLE)
+                .withClassAnnotation(NON_EXTENDABLE)
                 .assertClassWarning(IncompatibilityMessages.CLASS_MADE_FINAL);
     }
 
     @Test
     public void testNonExtendableApiMethodMadeAbstractWarnsByDefault() {
-        // Making a method abstract on a non-extendable type is reported as a warning by default
+        // Making a method abstract breaks subclasses that rely on the implementation,
+        // but @NonExtendable marks subclassing as not supported, so the break is
+        // downgraded to a warning.
         fixtureComparison("Method/PublicMethodMadeAbstract", "A")
                 .api()
-                .withBaseClassAnnotation(NON_EXTENDABLE)
-                .assertMemberWarning("thing", "()V", IncompatibilityMessages.METHOD_MADE_ABSTRACT);
+                .withClassAnnotation(NON_EXTENDABLE)
+                .assertMemberWarning(METHOD_NAME, METHOD_DESC, IncompatibilityMessages.METHOD_MADE_ABSTRACT);
     }
 
     @Test
     public void testNonExtendableApiMethodMadeFinalWarnsByDefault() {
-        // Making a method final on a non-extendable type is reported as a warning by default
+        // Making a method final breaks overrides, but @NonExtendable marks subclassing
+        // as not supported, so the break is downgraded to a warning.
         fixtureComparison("Method/PublicMethodMadeFinal", "A")
                 .api()
-                .withBaseClassAnnotation(NON_EXTENDABLE)
-                .assertMemberWarning("thing", "()V", IncompatibilityMessages.METHOD_MADE_FINAL);
+                .withClassAnnotation(NON_EXTENDABLE)
+                .assertMemberWarning(METHOD_NAME, METHOD_DESC, IncompatibilityMessages.METHOD_MADE_FINAL);
     }
 
     @Test
     public void testNonExtendableMethodAnnotationAllowsMethodMadeFinal() {
-        // A method can be marked non-extendable directly
+        // Making a method final breaks overrides, but method-level @NonExtendable
+        // marks overriding as not supported, so the break is downgraded to a warning.
         fixtureComparison("Method/PublicMethodMadeFinal", "A")
                 .api()
-                .withBaseMethodAnnotation("thing", "()V", NON_EXTENDABLE)
-                .assertMemberWarning("thing", "()V", IncompatibilityMessages.METHOD_MADE_FINAL);
+                .withMethodAnnotation(METHOD_NAME, METHOD_DESC, NON_EXTENDABLE)
+                .assertMemberWarning(METHOD_NAME, METHOD_DESC, IncompatibilityMessages.METHOD_MADE_FINAL);
     }
 
     @Test
     public void testNonExtendableApiCheckModeSkipSuppressesAllowedIncompatibility() {
-        // SKIP suppresses otherwise-allowed non-extendable API incompatibilities, matching internal API mode behavior
+        // SKIP mode suppresses extension-only breaks when the API marks extension as
+        // not supported, so the result remains compatible.
         fixtureComparison("Class/PublicClassMadeFinal", "A")
                 .api()
                 .withNonExtendableApiMode(NonExtendableApiCheckMode.SKIP)
-                .withBaseClassAnnotation(NON_EXTENDABLE)
+                .withClassAnnotation(NON_EXTENDABLE)
                 .assertCompatible();
     }
 
     @Test
     public void testCustomNonExtendableAnnotationWarnsWhenConfigured() {
-        // Custom non-extendable annotations apply when configured
+        // Configured custom markers use the same contract as @NonExtendable, so
+        // extension-only breaks are downgraded to warnings.
         fixtureComparison("Class/PublicClassMadeFinal", "A")
                 .api()
                 .withNonExtendableApiAnnotations(ImmutableList.of(CUSTOM_NON_EXTENDABLE))
-                .withBaseClassAnnotation(CUSTOM_NON_EXTENDABLE)
+                .withClassAnnotation(CUSTOM_NON_EXTENDABLE)
                 .assertClassWarning(IncompatibilityMessages.CLASS_MADE_FINAL);
     }
 
     @Test
     public void testNonExtendableAnnotationBinaryNameIsNormalized() {
-        // Configured annotations may use Java binary names instead of JVM descriptors
+        // Binary-name configuration resolves to the same marker descriptor, so the
+        // same @NonExtendable compatibility policy applies.
         fixtureComparison("Class/PublicClassMadeFinal", "A")
                 .api()
                 .withNonExtendableApiAnnotations(ImmutableList.of("org.jetbrains.annotations.ApiStatus$NonExtendable"))
-                .withBaseClassAnnotation(NON_EXTENDABLE)
+                .withClassAnnotation(NON_EXTENDABLE)
                 .assertClassWarning(IncompatibilityMessages.CLASS_MADE_FINAL);
     }
 
     @Test
     public void testInternalApiStatusCanWarnUsingSeparateCheckMode() {
-        // Internal API remains controlled by the internal annotation mode, separately from non-extendable API compatibility
+        // Deleting a visible class breaks callers, but @Internal marks the class as
+        // not part of the supported API, so WARN mode downgrades the break to a warning.
         fixtureComparison("Class/InternalClassDeleted", "A")
                 .api()
                 .withInternalAnnotationMode(InternalAnnotationCheckMode.WARN)
                 .assertClassWarning(IncompatibilityMessages.API_CLASS_MISSING);
     }
 
+    // ApiStatus marker annotations are compatibility-affecting API contract changes
+
+    @Test
+    public void testInternalAnnotationAddedToClassIsReportedAsError() {
+        // Adding @Internal removes the class from the supported API contract, so the
+        // annotation change is reported as an error.
+        assertClassIncompatible(
+                compareApiStatusAnnotationChange(publicClass("A"), publicClass("A", INTERNAL)),
+                "A",
+                IncompatibilityMessages.ANNOTATION_ADDED
+        );
+    }
+
+    @Test
+    public void testInternalAnnotationRemovedFromClassIsReportedAsError() {
+        // Removing @Internal adds the class to the supported API contract, so the
+        // annotation change is reported as an error.
+        assertClassIncompatible(
+                compareApiStatusAnnotationChange(publicClass("A", INTERNAL), publicClass("A")),
+                "A",
+                IncompatibilityMessages.ANNOTATION_REMOVED
+        );
+    }
+
+    @Test
+    public void testInternalAnnotationAddedToMethodIsReportedAsError() {
+        // Adding @Internal removes the method from the supported API contract, so the
+        // annotation change is reported as an error.
+        assertIncompatible(
+                compareApiStatusAnnotationChange(publicClassWithPublicMethod("A"), publicClassWithAnnotatedPublicMethod("A", INTERNAL)),
+                "A",
+                METHOD_NAME,
+                METHOD_DESC,
+                true,
+                IncompatibilityMessages.ANNOTATION_ADDED
+        );
+    }
+
+    @Test
+    public void testInternalAnnotationRemovedFromMethodIsReportedAsError() {
+        // Removing @Internal adds the method to the supported API contract, so the
+        // annotation change is reported as an error.
+        assertIncompatible(
+                compareApiStatusAnnotationChange(publicClassWithAnnotatedPublicMethod("A", INTERNAL), publicClassWithPublicMethod("A")),
+                "A",
+                METHOD_NAME,
+                METHOD_DESC,
+                true,
+                IncompatibilityMessages.ANNOTATION_REMOVED
+        );
+    }
+
+    @Test
+    public void testNonExtendableAnnotationAddedToClassIsReportedAsError() {
+        // Adding @NonExtendable removes supported subclassing from the class contract,
+        // so the annotation change is reported as an error.
+        assertClassIncompatible(
+                compareApiStatusAnnotationChange(publicClass("A"), publicClass("A", NON_EXTENDABLE)),
+                "A",
+                IncompatibilityMessages.ANNOTATION_ADDED
+        );
+    }
+
+    @Test
+    public void testNonExtendableAnnotationRemovedFromClassIsReportedAsError() {
+        // Removing @NonExtendable adds supported subclassing to the class contract, so
+        // the annotation change is reported as an error.
+        assertClassIncompatible(
+                compareApiStatusAnnotationChange(publicClass("A", NON_EXTENDABLE), publicClass("A")),
+                "A",
+                IncompatibilityMessages.ANNOTATION_REMOVED
+        );
+    }
+
+    @Test
+    public void testNonExtendableAnnotationAddedToMethodIsReportedAsError() {
+        // Adding @NonExtendable removes supported overriding from the method contract,
+        // so the annotation change is reported as an error.
+        assertIncompatible(
+                compareApiStatusAnnotationChange(publicClassWithPublicMethod("A"), publicClassWithAnnotatedPublicMethod("A", NON_EXTENDABLE)),
+                "A",
+                METHOD_NAME,
+                METHOD_DESC,
+                true,
+                IncompatibilityMessages.ANNOTATION_ADDED
+        );
+    }
+
+    @Test
+    public void testNonExtendableAnnotationRemovedFromMethodIsReportedAsError() {
+        // Removing @NonExtendable adds supported overriding to the method contract, so
+        // the annotation change is reported as an error.
+        assertIncompatible(
+                compareApiStatusAnnotationChange(publicClassWithAnnotatedPublicMethod("A", NON_EXTENDABLE), publicClassWithPublicMethod("A")),
+                "A",
+                METHOD_NAME,
+                METHOD_DESC,
+                true,
+                IncompatibilityMessages.ANNOTATION_REMOVED
+        );
+    }
+
     // Cases that can be kept strict with ERROR mode
 
     @Test
     public void testNonExtendableApiClassMadeFinalInErrorModeRemainsError() {
-        // ERROR mode preserves strict compatibility checks
+        // ERROR mode keeps extension-only breaks as errors, so finalizing the class
+        // reports a subclassing compatibility break.
         fixtureComparison("Class/PublicClassMadeFinal", "A")
                 .api()
                 .withNonExtendableApiMode(NonExtendableApiCheckMode.ERROR)
-                .withBaseClassAnnotation(NON_EXTENDABLE)
+                .withClassAnnotation(NON_EXTENDABLE)
                 .assertClassError(IncompatibilityMessages.CLASS_MADE_FINAL);
     }
 
     @Test
     public void testNonExtendableApiMethodMadeAbstractInErrorModeRemainsError() {
-        // ERROR mode preserves strict compatibility checks
+        // ERROR mode keeps extension-only breaks as errors, so making the method
+        // abstract reports a subclassing compatibility break.
         fixtureComparison("Method/PublicMethodMadeAbstract", "A")
                 .api()
                 .withNonExtendableApiMode(NonExtendableApiCheckMode.ERROR)
-                .withBaseClassAnnotation(NON_EXTENDABLE)
-                .assertMemberError("thing", "()V", IncompatibilityMessages.METHOD_MADE_ABSTRACT);
+                .withClassAnnotation(NON_EXTENDABLE)
+                .assertMemberError(METHOD_NAME, METHOD_DESC, IncompatibilityMessages.METHOD_MADE_ABSTRACT);
     }
 
     @Test
     public void testNonExtendableApiMethodMadeFinalInErrorModeRemainsError() {
-        // ERROR mode preserves strict compatibility checks
+        // ERROR mode keeps extension-only breaks as errors, so making the method final
+        // reports an overriding compatibility break.
         fixtureComparison("Method/PublicMethodMadeFinal", "A")
                 .api()
                 .withNonExtendableApiMode(NonExtendableApiCheckMode.ERROR)
-                .withBaseClassAnnotation(NON_EXTENDABLE)
-                .assertMemberError("thing", "()V", IncompatibilityMessages.METHOD_MADE_FINAL);
+                .withClassAnnotation(NON_EXTENDABLE)
+                .assertMemberError(METHOD_NAME, METHOD_DESC, IncompatibilityMessages.METHOD_MADE_FINAL);
     }
 
     // Cases that should still report errors even with the most permissive non-extendable mode
 
     @Test
     public void testCustomNonExtendableAnnotationRequiresConfiguration() {
-        // Custom non-extendable annotations only apply when configured
+        // Unconfigured custom markers have no compatibility policy, so finalizing the
+        // class reports a subclassing compatibility break.
         fixtureComparison("Class/PublicClassMadeFinal", "A")
                 .api()
                 .withNonExtendableApiMode(NonExtendableApiCheckMode.SKIP)
-                .withBaseClassAnnotation(CUSTOM_NON_EXTENDABLE)
+                .withClassAnnotation(CUSTOM_NON_EXTENDABLE)
                 .assertClassError(IncompatibilityMessages.CLASS_MADE_FINAL);
     }
 
     @Test
     public void testNonExtendableBinaryClassMadeFinalRemainsError() {
-        // Non-extendable API compatibility does not relax binary compatibility
+        // Binary mode checks JVM compatibility, so API policy markers cannot downgrade
+        // final-class breaks to warnings.
         fixtureComparison("Class/PublicClassMadeFinal", "A")
                 .binary()
                 .withNonExtendableApiMode(NonExtendableApiCheckMode.SKIP)
-                .withBaseClassAnnotation(NON_EXTENDABLE)
+                .withClassAnnotation(NON_EXTENDABLE)
                 .assertClassError(IncompatibilityMessages.CLASS_MADE_FINAL);
     }
 
     @Test
     public void testNonExtendableBinaryMethodMadeAbstractRemainsError() {
-        // Non-extendable API compatibility does not relax binary compatibility
+        // Binary mode checks JVM compatibility, so API policy markers cannot downgrade
+        // abstract-method breaks to warnings.
         fixtureComparison("Method/PublicMethodMadeAbstract", "A")
                 .binary()
                 .withNonExtendableApiMode(NonExtendableApiCheckMode.SKIP)
-                .withBaseClassAnnotation(NON_EXTENDABLE)
-                .assertMemberError("thing", "()V", IncompatibilityMessages.METHOD_MADE_ABSTRACT);
+                .withClassAnnotation(NON_EXTENDABLE)
+                .assertMemberError(METHOD_NAME, METHOD_DESC, IncompatibilityMessages.METHOD_MADE_ABSTRACT);
     }
 
     @Test
     public void testNonExtendableDoesNotAllowUnrelatedIncompatibilities() {
-        // Non-extendable API compatibility only applies to extension-only incompatibilities
+        // Making a public field final is not an extension-only break, so
+        // @NonExtendable cannot downgrade or suppress it.
         fixtureComparison("Field/PublicFieldMadeFinal", "A")
                 .api()
                 .withNonExtendableApiMode(NonExtendableApiCheckMode.SKIP)
-                .withBaseClassAnnotation(NON_EXTENDABLE)
+                .withClassAnnotation(NON_EXTENDABLE)
                 .assertMemberError("buzz", "Z", IncompatibilityMessages.FIELD_MADE_FINAL);
     }
 
     @Test
     public void testOuterNonExtendableAnnotationDoesNotApplyToNestedClass() {
-        // Marking an outer class non-extendable does not mark its nested class non-extendable
+        // A nested class is a separate API element, so an outer @NonExtendable marker
+        // cannot downgrade or suppress the nested class's subclassing break.
         assertClassIncompatible(compareNestedClassMadeFinalWithNonExtendableOuter(), "Outer$Nested", IncompatibilityMessages.CLASS_MADE_FINAL);
     }
 
     @Test
     public void testInternalApiStatusCanRemainErrorUsingSeparateCheckMode() {
-        // Internal API remains controlled by the internal annotation mode, separately from non-extendable API compatibility
+        // ERROR mode keeps @Internal elements in strict API checks, so deleting the
+        // class reports a compatibility error.
         fixtureComparison("Class/InternalClassDeleted", "A")
                 .api()
                 .withNonExtendableApiMode(NonExtendableApiCheckMode.SKIP)
@@ -196,8 +320,8 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
                 .assertClassError(IncompatibilityMessages.API_CLASS_MISSING);
     }
 
-    private FixtureComparisonBuilder fixtureComparison(String folderName, String className) {
-        return new FixtureComparisonBuilder(folderName, className);
+    private FixtureComparisonModeBuilder fixtureComparison(String folderName, String className) {
+        return new FixtureComparisonModeBuilder(folderName, className);
     }
 
     private ClassInfoComparisonResults compareNestedClassMadeFinalWithNonExtendableOuter() {
@@ -225,28 +349,56 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
         );
     }
 
-    private final class FixtureComparisonBuilder {
+    private ClassInfoComparisonResults compareApiStatusAnnotationChange(ClassInfo baseClass, ClassInfo inputClass) {
+        ClassInfoCache baseCache = ClassInfoCache.fromMaps(ImmutableMap.of(baseClass.getName(), baseClass), ImmutableMap.of());
+        ClassInfoCache inputCache = ClassInfoCache.fromMaps(ImmutableMap.of(inputClass.getName(), inputClass), ImmutableMap.of());
+
+        return ClassInfoComparer.compare(
+                false,
+                null,
+                InternalAnnotationCheckMode.DEFAULT_INTERNAL_ANNOTATIONS,
+                InternalAnnotationCheckMode.ERROR,
+                NonExtendableApiCheckMode.DEFAULT_MODE,
+                NonExtendableApiCheckMode.DEFAULT_NON_EXTENDABLE_API_ANNOTATIONS,
+                baseCache,
+                baseClass,
+                inputCache,
+                inputClass
+        );
+    }
+
+    private final class FixtureComparisonModeBuilder {
         private final String folderName;
         private final String className;
-        private Boolean checkBinary;
-        private InternalAnnotationCheckMode internalAnnotationCheckMode = InternalAnnotationCheckMode.ERROR;
-        private NonExtendableApiCheckMode nonExtendableApiCheckMode = NonExtendableApiCheckMode.DEFAULT_MODE;
-        private List<String> nonExtendableApiAnnotations = NonExtendableApiCheckMode.DEFAULT_NON_EXTENDABLE_API_ANNOTATIONS;
-        private Consumer<ClassInfo> baseClassConfigurer = classInfo -> {};
 
-        private FixtureComparisonBuilder(String folderName, String className) {
+        private FixtureComparisonModeBuilder(String folderName, String className) {
             this.folderName = folderName;
             this.className = className;
         }
 
         private FixtureComparisonBuilder api() {
-            this.checkBinary = false;
-            return this;
+            return new FixtureComparisonBuilder(this.folderName, this.className, false);
         }
 
         private FixtureComparisonBuilder binary() {
-            this.checkBinary = true;
-            return this;
+            return new FixtureComparisonBuilder(this.folderName, this.className, true);
+        }
+    }
+
+    private final class FixtureComparisonBuilder {
+        private final String folderName;
+        private final String className;
+        private final boolean checkBinary;
+        private InternalAnnotationCheckMode internalAnnotationCheckMode = InternalAnnotationCheckMode.ERROR;
+        private NonExtendableApiCheckMode nonExtendableApiCheckMode = NonExtendableApiCheckMode.DEFAULT_MODE;
+        private List<String> nonExtendableApiAnnotations = NonExtendableApiCheckMode.DEFAULT_NON_EXTENDABLE_API_ANNOTATIONS;
+        private Consumer<ClassInfo> baseClassConfigurer = classInfo -> {};
+        private Consumer<ClassInfo> inputClassConfigurer = classInfo -> {};
+
+        private FixtureComparisonBuilder(String folderName, String className, boolean checkBinary) {
+            this.folderName = folderName;
+            this.className = className;
+            this.checkBinary = checkBinary;
         }
 
         private FixtureComparisonBuilder withInternalAnnotationMode(InternalAnnotationCheckMode internalAnnotationCheckMode) {
@@ -264,8 +416,20 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
             return this;
         }
 
+        private FixtureComparisonBuilder withClassAnnotation(String annotation) {
+            return withBaseClassAnnotation(annotation).withInputClassAnnotation(annotation);
+        }
+
         private FixtureComparisonBuilder withBaseClassAnnotation(String annotation) {
             return withBaseClass(classInfo -> annotate(classInfo, annotation));
+        }
+
+        private FixtureComparisonBuilder withInputClassAnnotation(String annotation) {
+            return withInputClass(classInfo -> annotate(classInfo, annotation));
+        }
+
+        private FixtureComparisonBuilder withMethodAnnotation(String name, String desc, String annotation) {
+            return withBaseMethodAnnotation(name, desc, annotation).withInputMethodAnnotation(name, desc, annotation);
         }
 
         private FixtureComparisonBuilder withBaseMethodAnnotation(String name, String desc, String annotation) {
@@ -276,9 +440,26 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
             });
         }
 
+        private FixtureComparisonBuilder withInputMethodAnnotation(String name, String desc, String annotation) {
+            return withInputClass(classInfo -> {
+                MethodInfo methodInfo = classInfo.getMethod(name, desc);
+                Assert.assertNotNull("Method " + name + desc + " not found", methodInfo);
+                annotate(methodInfo, annotation);
+            });
+        }
+
         private FixtureComparisonBuilder withBaseClass(Consumer<ClassInfo> configurer) {
             Consumer<ClassInfo> previousConfigurer = this.baseClassConfigurer;
             this.baseClassConfigurer = classInfo -> {
+                previousConfigurer.accept(classInfo);
+                configurer.accept(classInfo);
+            };
+            return this;
+        }
+
+        private FixtureComparisonBuilder withInputClass(Consumer<ClassInfo> configurer) {
+            Consumer<ClassInfo> previousConfigurer = this.inputClassConfigurer;
+            this.inputClassConfigurer = classInfo -> {
                 previousConfigurer.accept(classInfo);
                 configurer.accept(classInfo);
             };
@@ -306,9 +487,11 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
         }
 
         private ClassInfoComparisonResults results() {
-            Assert.assertNotNull("Compatibility mode must be configured with api() or binary()", this.checkBinary);
             return getComparisonResults(this.folderName, this.className, (baseCache, baseClassInfo, inputCache, inputClassInfo) -> {
                 this.baseClassConfigurer.accept(baseClassInfo);
+                if (inputClassInfo != null) {
+                    this.inputClassConfigurer.accept(inputClassInfo);
+                }
                 return ClassInfoComparer.compare(
                         this.checkBinary,
                         null,
@@ -335,6 +518,24 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
 
     private static ClassInfo publicFinalClass(String name, String... annotations) {
         return classInfo(name, Opcodes.ACC_PUBLIC | Opcodes.ACC_SUPER | Opcodes.ACC_FINAL, annotations);
+    }
+
+    private static ClassInfo publicClassWithAnnotatedPublicMethod(String name, String annotation) {
+        ClassInfo classInfo = publicClassWithPublicMethod(name);
+        MethodInfo methodInfo = classInfo.getMethod(METHOD_NAME, METHOD_DESC);
+        Assert.assertNotNull("Method " + METHOD_NAME + METHOD_DESC + " not found", methodInfo);
+        annotate(methodInfo, annotation);
+        return classInfo;
+    }
+
+    private static ClassInfo publicClassWithPublicMethod(String name) {
+        ClassNode node = new ClassNode();
+        node.version = Opcodes.V1_8;
+        node.access = Opcodes.ACC_PUBLIC | Opcodes.ACC_SUPER;
+        node.name = name;
+        node.superName = "java/lang/Object";
+        node.methods.add(new MethodNode(Opcodes.ACC_PUBLIC, METHOD_NAME, METHOD_DESC, null, null));
+        return new ClassInfo(node);
     }
 
     private static ClassInfo classInfo(String name, int access, String... annotations) {

--- a/src/test/java/net/neoforged/jarcompatibilitychecker/test/ApiStatusCompatibilityTests.java
+++ b/src/test/java/net/neoforged/jarcompatibilitychecker/test/ApiStatusCompatibilityTests.java
@@ -32,31 +32,28 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
     // Cases that ApiStatus compatibility can downgrade or suppress
 
     @Test
-    public void testNonExtendableApiClassMadeFinalWarnsWhenOptedIn() {
-        // Making a non-extendable public class final can be downgraded to a warning
+    public void testNonExtendableApiClassMadeFinalWarnsByDefault() {
+        // Making a non-extendable public class final is reported as a warning by default
         fixtureComparison("Class/PublicClassMadeFinal", "A")
                 .api()
-                .withNonExtendableApiMode(NonExtendableApiCheckMode.WARN)
                 .withBaseClassAnnotation(NON_EXTENDABLE)
                 .assertClassWarning(IncompatibilityMessages.CLASS_MADE_FINAL);
     }
 
     @Test
-    public void testNonExtendableApiMethodMadeAbstractWarnsWhenOptedIn() {
-        // Making a method abstract on a non-extendable type can be downgraded to a warning
+    public void testNonExtendableApiMethodMadeAbstractWarnsByDefault() {
+        // Making a method abstract on a non-extendable type is reported as a warning by default
         fixtureComparison("Method/PublicMethodMadeAbstract", "A")
                 .api()
-                .withNonExtendableApiMode(NonExtendableApiCheckMode.WARN)
                 .withBaseClassAnnotation(NON_EXTENDABLE)
                 .assertMemberWarning("thing", "()V", IncompatibilityMessages.METHOD_MADE_ABSTRACT);
     }
 
     @Test
-    public void testNonExtendableApiMethodMadeFinalWarnsWhenOptedIn() {
-        // Making a method final on a non-extendable type can be downgraded to a warning
+    public void testNonExtendableApiMethodMadeFinalWarnsByDefault() {
+        // Making a method final on a non-extendable type is reported as a warning by default
         fixtureComparison("Method/PublicMethodMadeFinal", "A")
                 .api()
-                .withNonExtendableApiMode(NonExtendableApiCheckMode.WARN)
                 .withBaseClassAnnotation(NON_EXTENDABLE)
                 .assertMemberWarning("thing", "()V", IncompatibilityMessages.METHOD_MADE_FINAL);
     }
@@ -66,7 +63,6 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
         // A method can be marked non-extendable directly
         fixtureComparison("Method/PublicMethodMadeFinal", "A")
                 .api()
-                .withNonExtendableApiMode(NonExtendableApiCheckMode.WARN)
                 .withBaseMethodAnnotation("thing", "()V", NON_EXTENDABLE)
                 .assertMemberWarning("thing", "()V", IncompatibilityMessages.METHOD_MADE_FINAL);
     }
@@ -86,7 +82,6 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
         // Custom non-extendable annotations apply when configured
         fixtureComparison("Class/PublicClassMadeFinal", "A")
                 .api()
-                .withNonExtendableApiMode(NonExtendableApiCheckMode.WARN)
                 .withNonExtendableApiAnnotations(ImmutableList.of(CUSTOM_NON_EXTENDABLE))
                 .withBaseClassAnnotation(CUSTOM_NON_EXTENDABLE)
                 .assertClassWarning(IncompatibilityMessages.CLASS_MADE_FINAL);
@@ -97,7 +92,6 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
         // Configured annotations may use Java binary names instead of JVM descriptors
         fixtureComparison("Class/PublicClassMadeFinal", "A")
                 .api()
-                .withNonExtendableApiMode(NonExtendableApiCheckMode.WARN)
                 .withNonExtendableApiAnnotations(ImmutableList.of("org.jetbrains.annotations.ApiStatus$NonExtendable"))
                 .withBaseClassAnnotation(NON_EXTENDABLE)
                 .assertClassWarning(IncompatibilityMessages.CLASS_MADE_FINAL);
@@ -112,31 +106,34 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
                 .assertClassWarning(IncompatibilityMessages.API_CLASS_MISSING);
     }
 
-    // Cases that require opting in to ApiStatus compatibility
+    // Cases that can be kept strict with ERROR mode
 
     @Test
-    public void testNonExtendableApiClassMadeFinalWithoutOptInRemainsError() {
-        // Making a non-extendable public class final is still an error unless the non-extendable policy is enabled
+    public void testNonExtendableApiClassMadeFinalInErrorModeRemainsError() {
+        // ERROR mode preserves strict compatibility checks
         fixtureComparison("Class/PublicClassMadeFinal", "A")
                 .api()
+                .withNonExtendableApiMode(NonExtendableApiCheckMode.ERROR)
                 .withBaseClassAnnotation(NON_EXTENDABLE)
                 .assertClassError(IncompatibilityMessages.CLASS_MADE_FINAL);
     }
 
     @Test
-    public void testNonExtendableApiMethodMadeAbstractWithoutOptInRemainsError() {
-        // Making a method abstract on a non-extendable type is still an error unless the non-extendable policy is enabled
+    public void testNonExtendableApiMethodMadeAbstractInErrorModeRemainsError() {
+        // ERROR mode preserves strict compatibility checks
         fixtureComparison("Method/PublicMethodMadeAbstract", "A")
                 .api()
+                .withNonExtendableApiMode(NonExtendableApiCheckMode.ERROR)
                 .withBaseClassAnnotation(NON_EXTENDABLE)
                 .assertMemberError("thing", "()V", IncompatibilityMessages.METHOD_MADE_ABSTRACT);
     }
 
     @Test
-    public void testNonExtendableApiMethodMadeFinalWithoutOptInRemainsError() {
-        // Making a method final on a non-extendable type is still an error unless the non-extendable policy is enabled
+    public void testNonExtendableApiMethodMadeFinalInErrorModeRemainsError() {
+        // ERROR mode preserves strict compatibility checks
         fixtureComparison("Method/PublicMethodMadeFinal", "A")
                 .api()
+                .withNonExtendableApiMode(NonExtendableApiCheckMode.ERROR)
                 .withBaseClassAnnotation(NON_EXTENDABLE)
                 .assertMemberError("thing", "()V", IncompatibilityMessages.METHOD_MADE_FINAL);
     }

--- a/src/test/java/net/neoforged/jarcompatibilitychecker/test/ApiStatusCompatibilityTests.java
+++ b/src/test/java/net/neoforged/jarcompatibilitychecker/test/ApiStatusCompatibilityTests.java
@@ -133,12 +133,13 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
     }
 
     @Test
-    public void testInternalAnnotationRemovedFromClassIsReportedAsError() {
-        // Removing @Internal adds the class to the supported API contract, so the
-        // annotation change is reported as an error.
+    public void testInternalAnnotationRemovedFromClassWarnsByDefault() {
+        // Removing @Internal adds the class to the supported API contract. That
+        // widens the contract, so the annotation change is reported as a warning.
         assertClassIncompatible(
                 compareApiStatusAnnotationChange(publicClass("A", INTERNAL), publicClass("A")),
                 "A",
+                false,
                 IncompatibilityMessages.ANNOTATION_REMOVED
         );
     }
@@ -158,15 +159,15 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
     }
 
     @Test
-    public void testInternalAnnotationRemovedFromMethodIsReportedAsError() {
-        // Removing @Internal adds the method to the supported API contract, so the
-        // annotation change is reported as an error.
+    public void testInternalAnnotationRemovedFromMethodWarnsByDefault() {
+        // Removing @Internal adds the method to the supported API contract. That
+        // widens the contract, so the annotation change is reported as a warning.
         assertIncompatible(
                 compareApiStatusAnnotationChange(publicClassWithAnnotatedPublicMethod("A", INTERNAL), publicClassWithPublicMethod("A")),
                 "A",
                 METHOD_NAME,
                 METHOD_DESC,
-                true,
+                false,
                 IncompatibilityMessages.ANNOTATION_REMOVED
         );
     }
@@ -183,12 +184,13 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
     }
 
     @Test
-    public void testNonExtendableAnnotationRemovedFromClassIsReportedAsError() {
-        // Removing @NonExtendable adds supported subclassing to the class contract, so
-        // the annotation change is reported as an error.
+    public void testNonExtendableAnnotationRemovedFromClassWarnsByDefault() {
+        // Removing @NonExtendable adds supported subclassing to the class contract.
+        // That widens the contract, so the annotation change is reported as a warning.
         assertClassIncompatible(
                 compareApiStatusAnnotationChange(publicClass("A", NON_EXTENDABLE), publicClass("A")),
                 "A",
+                false,
                 IncompatibilityMessages.ANNOTATION_REMOVED
         );
     }
@@ -208,15 +210,15 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
     }
 
     @Test
-    public void testNonExtendableAnnotationRemovedFromMethodIsReportedAsError() {
-        // Removing @NonExtendable adds supported overriding to the method contract, so
-        // the annotation change is reported as an error.
+    public void testNonExtendableAnnotationRemovedFromMethodWarnsByDefault() {
+        // Removing @NonExtendable adds supported overriding to the method contract.
+        // That widens the contract, so the annotation change is reported as a warning.
         assertIncompatible(
                 compareApiStatusAnnotationChange(publicClassWithAnnotatedPublicMethod("A", NON_EXTENDABLE), publicClassWithPublicMethod("A")),
                 "A",
                 METHOD_NAME,
                 METHOD_DESC,
-                true,
+                false,
                 IncompatibilityMessages.ANNOTATION_REMOVED
         );
     }
@@ -357,7 +359,7 @@ public class ApiStatusCompatibilityTests extends BaseCompatibilityTest {
                 false,
                 null,
                 InternalAnnotationCheckMode.DEFAULT_INTERNAL_ANNOTATIONS,
-                InternalAnnotationCheckMode.ERROR,
+                InternalAnnotationCheckMode.DEFAULT_MODE,
                 NonExtendableApiCheckMode.DEFAULT_MODE,
                 NonExtendableApiCheckMode.DEFAULT_NON_EXTENDABLE_API_ANNOTATIONS,
                 baseCache,

--- a/src/test/java/net/neoforged/jarcompatibilitychecker/test/BaseCompatibilityTest.java
+++ b/src/test/java/net/neoforged/jarcompatibilitychecker/test/BaseCompatibilityTest.java
@@ -39,6 +39,13 @@ public abstract class BaseCompatibilityTest {
             throw new IllegalArgumentException("Must provide at least one incompatibility to test");
 
         ClassInfoComparisonResults comparisonResults = getComparisonResults(checkBinary, folder, className);
+        assertIncompatible(comparisonResults, className, testIncompatibilities);
+    }
+
+    protected void assertIncompatible(ClassInfoComparisonResults comparisonResults, String className, IncompatibilityData... testIncompatibilities) {
+        if (testIncompatibilities.length == 0)
+            throw new IllegalArgumentException("Must provide at least one incompatibility to test");
+
         Assert.assertFalse(className + " was compatible when incompatibilities were expected", comparisonResults.isCompatible());
 
         List<Incompatibility<?>> incompatibilities = comparisonResults.getIncompatibilities();
@@ -58,8 +65,16 @@ public abstract class BaseCompatibilityTest {
         assertClassIncompatible(checkBinary, folder, className, true, message, formatArgs);
     }
 
+    protected void assertClassIncompatible(ClassInfoComparisonResults comparisonResults, String className, String message, Object... formatArgs) {
+        assertClassIncompatible(comparisonResults, className, true, message, formatArgs);
+    }
+
     protected void assertClassIncompatible(boolean checkBinary, String folder, String className, boolean isError, String message, Object... formatArgs) {
         assertIncompatible(checkBinary, folder, className, className, null, isError, message, formatArgs);
+    }
+
+    protected void assertClassIncompatible(ClassInfoComparisonResults comparisonResults, String className, boolean isError, String message, Object... formatArgs) {
+        assertIncompatible(comparisonResults, className, className, null, isError, message, formatArgs);
     }
 
     protected void assertIncompatible(boolean checkBinary, String folder, String className, String name, @Nullable String desc, String message, Object... formatArgs) {
@@ -70,6 +85,13 @@ public abstract class BaseCompatibilityTest {
         if (formatArgs.length > 0)
             message = String.format(Locale.ROOT, message, formatArgs);
         ClassInfoComparisonResults comparisonResults = getComparisonResults(checkBinary, folder, className);
+        assertIncompatible(comparisonResults, className, name, desc, isError, message);
+    }
+
+    protected void assertIncompatible(ClassInfoComparisonResults comparisonResults, String className, String name, @Nullable String desc, boolean isError, String message,
+            Object... formatArgs) {
+        if (formatArgs.length > 0)
+            message = String.format(Locale.ROOT, message, formatArgs);
         Assert.assertFalse(className + " was compatible when incompatibilities were expected", comparisonResults.isCompatible());
 
         List<Incompatibility<?>> incompatibilities = comparisonResults.getIncompatibilities();
@@ -84,10 +106,19 @@ public abstract class BaseCompatibilityTest {
 
     protected void assertCompatible(boolean checkBinary, String folder, String className) {
         ClassInfoComparisonResults comparisonResults = getComparisonResults(checkBinary, folder, className);
+        assertCompatible(comparisonResults, className);
+    }
+
+    protected void assertCompatible(ClassInfoComparisonResults comparisonResults, String className) {
         Assert.assertTrue(className + " had incompatibilities when none were expected: " + comparisonResults, comparisonResults.isCompatible());
     }
 
     protected ClassInfoComparisonResults getComparisonResults(boolean checkBinary, String folderName, String className) {
+        return getComparisonResults(folderName, className, (baseCache, baseClassInfo, inputCache, inputClassInfo) ->
+                ClassInfoComparer.compare(checkBinary, baseCache, baseClassInfo, inputCache, inputClassInfo));
+    }
+
+    protected ClassInfoComparisonResults getComparisonResults(String folderName, String className, Comparison comparison) {
         try {
             Path folder = getRoot().resolve(folderName);
             if (!folder.toRealPath().toString().equals(folder.toAbsolutePath().toString()))
@@ -108,10 +139,15 @@ public abstract class BaseCompatibilityTest {
             ClassInfo baseClassInfo = baseCache.getMainClassInfo(className);
             Assert.assertNotNull("Class with name " + className + " not found in " + baseFolder, baseClassInfo);
 
-            return ClassInfoComparer.compare(checkBinary, baseCache, baseClassInfo, inputCache, inputCache.getMainClassInfo(className));
+            return comparison.compare(baseCache, baseClassInfo, inputCache, inputCache.getMainClassInfo(className));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @FunctionalInterface
+    protected interface Comparison {
+        ClassInfoComparisonResults compare(ClassInfoCache baseCache, ClassInfo baseClassInfo, ClassInfoCache inputCache, @Nullable ClassInfo inputClassInfo);
     }
 
     protected static class IncompatibilityData {


### PR DESCRIPTION
# Problem

I want to check JEI's API for incompatible changes, but I have a slightly more permissions breaking stance than JarCompatibilityChecker can support currently.
I use `org.jetbrains.annotations.ApiStatus$NonExtendable` to mark interfaces that people should only get from JEI, and so those classes can get away with a few extra things without breaking binary compatibility for anyone. (for example, adding new methods without a default implementation)

# Additions

This adds Additional API policy flags, described in the readme:
- `--non-extendable-api-check-mode SKIP|WARN|ERROR` - Controls extension-only incompatibilities on base API elements marked with configured non-extendable annotations. The default is `ERROR`, preserving strict compatibility unless this policy is explicitly enabled. `WARN` records applicable incompatibilities as warnings instead of errors. `SKIP` suppresses applicable incompatibilities.
- `--non-extendable-api-annotation <annotation>` - Configures the marker annotations for non-extendable API. This option may be repeated and defaults to `org.jetbrains.annotations.ApiStatus$NonExtendable` (`Lorg/jetbrains/annotations/ApiStatus$NonExtendable;`). Annotation names may be passed as Java binary class names or JVM descriptors. This lets public, non-extensible APIs evolve without failing compatibility checks for changes that only affect unsupported external implementations or overrides:
  - making a non-extendable class final;
  - making a method abstract on a non-extendable type;
  - making a method final on a non-extendable type, or on a method directly marked `@ApiStatus.NonExtendable`. 

I also added a note to the readme about the existing Internal controls:
- `--internal-annotation-check-mode WARN|SKIP|ERROR` and `--internal-annotation <annotation>` - Controls the separate internal API policy. By default, `org.jetbrains.annotations.ApiStatus$Internal` is treated as an internal API marker and internal incompatibilities are warnings. This is separate from `@ApiStatus.NonExtendable`: internal API means "not public API", while non-extendable API means "public to use, unsupported to implement or subclass."

# Open Questions

~~It's set to `ERROR` to keep the behavior the same, but should this be `SKIP` or `WARN` by default?~~
edit: @sciwhiz12 decided on `WARN` in discord, to match the Internal behavior