### PR TITLE
Fix Gradle failure handling without System.exit

### DIFF
--- a/plugin/src/main/groovy/net/neoforged/jarcompatibilitychecker/gradle/CompatibilityTask.groovy
+++ b/plugin/src/main/groovy/net/neoforged/jarcompatibilitychecker/gradle/CompatibilityTask.groovy
@@ -6,6 +6,7 @@ import groovy.transform.CompileStatic
 import net.neoforged.jarcompatibilitychecker.ConsoleTool
 import net.neoforged.jarcompatibilitychecker.core.NonExtendableApiCheckMode
 import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFileProperty
@@ -137,7 +138,7 @@ abstract class CompatibilityTask extends DefaultTask {
             inputs.add('--fail')
         }
 
-        ConsoleTool.main(inputs as String[])
+        final int exitCode = ConsoleTool.run(inputs as String[])
 
         if (output.isPresent() && globalOutput.isPresent()) {
             final output = this.output.get().asFile
@@ -148,6 +149,15 @@ abstract class CompatibilityTask extends DefaultTask {
                 global.put(projectName.get(), projectIncompats)
                 globalOutput.write(new JsonBuilder(global).toString())
             }
+        }
+
+        if (exitCode != 0) {
+            if (exitCode > 0) {
+                final count = exitCode == 125 ? 'at least 125' : exitCode.toString()
+                final report = output.isPresent() ? " See the report at ${output.get().asFile}." : ''
+                throw new GradleException("Jar compatibility check found ${count} error-level incompatibilit${exitCode == 1 ? 'y' : 'ies'}.${report}")
+            }
+            throw new GradleException("Jar compatibility check could not be completed (exit code ${exitCode}).")
         }
     }
 

--- a/src/main/java/net/neoforged/jarcompatibilitychecker/ConsoleTool.java
+++ b/src/main/java/net/neoforged/jarcompatibilitychecker/ConsoleTool.java
@@ -34,6 +34,19 @@ import java.util.Map;
 
 public class ConsoleTool {
     public static void main(String[] args) {
+        int exitCode = run(args);
+        if (exitCode != 0) {
+            System.exit(exitCode);
+        }
+    }
+
+    /**
+     * Runs the console tool without terminating the calling JVM.
+     *
+     * @param args the command-line arguments
+     * @return the exit code that would be used by the command-line entrypoint
+     */
+    public static int run(String[] args) {
         try {
             OptionParser parser = new OptionParser();
             OptionSpec<Void> apiO = parser.accepts("api", "Enables the API compatibility checking mode");
@@ -69,8 +82,7 @@ public class ConsoleTool {
                 System.err.println("Error: " + ex.getMessage());
                 System.err.println();
                 parser.printHelpOn(System.err);
-                System.exit(-1);
-                return;
+                return -1;
             }
 
             File baseJar = options.valueOf(baseJarO);
@@ -103,11 +115,12 @@ public class ConsoleTool {
 
             if (options.has(failO)) {
                 // Clamp to a max of 125 to prevent conflicting with special meaning exit codes - https://tldp.org/LDP/abs/html/exitcodes.html
-                System.exit(Math.min(125, incompatibilities.getKey()));
+                return Math.min(125, incompatibilities.getKey());
             }
+            return 0;
         } catch (Exception e) {
             e.printStackTrace();
-            System.exit(-1);
+            return -1;
         }
     }
 }


### PR DESCRIPTION
`System.exit` takes down the whole process, so for the gradle plugin it's nicer if we can return an error code on completion.